### PR TITLE
Back out changes to rust-hdf5.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  reviewers:
+  - sreenathkrishnan
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,15 +288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,8 +448,6 @@ dependencies = [
  "evalexpr",
  "graph_simple",
  "hdf5",
- "hdf5-sys",
- "hdf5x",
  "io_utils",
  "itertools",
  "mirror_sparse_matrix",
@@ -489,8 +478,6 @@ dependencies = [
  "evalexpr",
  "expr_tools",
  "hdf5",
- "hdf5-sys",
- "hdf5x",
  "io_utils",
  "itertools",
  "mirror_sparse_matrix",
@@ -517,8 +504,6 @@ dependencies = [
  "enclone_proto",
  "evalexpr",
  "hdf5",
- "hdf5-sys",
- "hdf5x",
  "io_utils",
  "itertools",
  "lazy_static",
@@ -555,8 +540,6 @@ dependencies = [
  "evalexpr",
  "expr_tools",
  "hdf5",
- "hdf5-sys",
- "hdf5x",
  "io_utils",
  "itertools",
  "mirror_sparse_matrix",
@@ -603,8 +586,6 @@ dependencies = [
  "enclone_proto",
  "enclone_stuff",
  "hdf5",
- "hdf5-sys",
- "hdf5x",
  "io_utils",
  "itertools",
  "rayon",
@@ -627,8 +608,6 @@ dependencies = [
  "equiv",
  "evalexpr",
  "hdf5",
- "hdf5-sys",
- "hdf5x",
  "io_utils",
  "itertools",
  "ndarray",
@@ -818,8 +797,8 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdf5"
-version = "0.8.1"
-source = "git+https://github.com/CompRD/hdf5-rust?branch=master#528bc89007f6795f367d780cabdf4dfbba2507c1"
+version = "0.8.0"
+source = "git+https://github.com/10XGenomics/hdf5-rust.git?branch=conda_nov2021#276926691a4c81298344dba3644945b04007e07a"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -835,82 +814,18 @@ dependencies = [
 
 [[package]]
 name = "hdf5-derive"
-version = "0.8.1"
-source = "git+https://github.com/CompRD/hdf5-rust?branch=master#528bc89007f6795f367d780cabdf4dfbba2507c1"
+version = "0.8.0"
+source = "git+https://github.com/10XGenomics/hdf5-rust.git?branch=conda_nov2021#276926691a4c81298344dba3644945b04007e07a"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "hdf5-src"
-version = "0.8.1"
-source = "git+https://github.com/CompRD/hdf5-rust?branch=master#528bc89007f6795f367d780cabdf4dfbba2507c1"
-dependencies = [
- "cmake",
- "libz-sys",
 ]
 
 [[package]]
 name = "hdf5-sys"
-version = "0.8.1"
-source = "git+https://github.com/CompRD/hdf5-rust?branch=master#528bc89007f6795f367d780cabdf4dfbba2507c1"
-dependencies = [
- "hdf5-src",
- "libc",
- "libloading",
- "libz-sys",
- "pkg-config",
- "regex",
- "serde",
- "serde_derive",
- "winreg",
-]
-
-[[package]]
-name = "hdf5-types"
-version = "0.8.1"
-source = "git+https://github.com/CompRD/hdf5-rust?branch=master#528bc89007f6795f367d780cabdf4dfbba2507c1"
-dependencies = [
- "ascii",
- "cfg-if",
- "hdf5-sys",
- "libc",
-]
-
-[[package]]
-name = "hdf5x"
 version = "0.8.0"
-source = "git+https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x?branch=conda_nov2021_as_hdf5x#343a9003e945edcf4f0fc44ce12e8ab7517c94cf"
-dependencies = [
- "bitflags",
- "cfg-if",
- "hdf5x-derive",
- "hdf5x-sys",
- "hdf5x-types",
- "lazy_static",
- "libc",
- "ndarray",
- "parking_lot",
- "paste",
-]
-
-[[package]]
-name = "hdf5x-derive"
-version = "0.8.0"
-source = "git+https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x?branch=conda_nov2021_as_hdf5x#343a9003e945edcf4f0fc44ce12e8ab7517c94cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "hdf5x-sys"
-version = "0.8.0"
-source = "git+https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x?branch=conda_nov2021_as_hdf5x#343a9003e945edcf4f0fc44ce12e8ab7517c94cf"
+source = "git+https://github.com/10XGenomics/hdf5-rust.git?branch=conda_nov2021#276926691a4c81298344dba3644945b04007e07a"
 dependencies = [
  "attohttpc",
  "bzip2",
@@ -926,13 +841,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdf5x-types"
+name = "hdf5-types"
 version = "0.8.0"
-source = "git+https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x?branch=conda_nov2021_as_hdf5x#343a9003e945edcf4f0fc44ce12e8ab7517c94cf"
+source = "git+https://github.com/10XGenomics/hdf5-rust.git?branch=conda_nov2021#276926691a4c81298344dba3644945b04007e07a"
 dependencies = [
  "ascii",
  "cfg-if",
- "hdf5x-sys",
+ "hdf5-sys",
  "libc",
 ]
 
@@ -1090,18 +1005,6 @@ name = "libm"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "lock_api"
@@ -1474,29 +1377,6 @@ dependencies = [
  "string_utils",
  "tables",
  "vector_utils",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -2045,12 +1925,6 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdj_ann"

--- a/deny.toml
+++ b/deny.toml
@@ -84,19 +84,6 @@ default = "deny"
 # canonical license text of a valid SPDX license file.
 # [possible values: any between 0.0 and 1.0].
 confidence-threshold = 0.6
-# Allow 1 or more licenses on a per-crate basis, so that particular licenses
-# aren't accepted for every possible crate as with the normal allow list
-
-# Some crates don't have (easily) machine readable licensing information,
-# adding a clarification entry for it allows you to manually specify the
-# licensing information
-[[licenses.clarify]]
-name = "hdf5-src"
-expression = "BSD-3-Clause"
-
-[[licenses.clarify.license-files]]
-path = "ext/1_13/COPYING"
-hash = 0xe1ee0ba2
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -142,10 +129,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     # TODO: remove this
     "https://github.com/Barandis/qd",
-    # TODO: remove this
-    "https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x",
-    # TODO: remove this
-    "https://github.com/CompRD/hdf5-rust",
 ]
 
 [sources.allow-org]

--- a/enclone/Cargo.toml
+++ b/enclone/Cargo.toml
@@ -50,8 +50,14 @@ assert_cmd = "2"
 
 [target.'cfg(not(windows))'.dependencies]
 pager = "0.16"
-hdf5x = { git = "https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x", branch = "conda_nov2021_as_hdf5x", default-features=false, features = ["conda"] }
 
-[target.'cfg(windows)'.dependencies]
-hdf5 = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false }
-hdf5-sys = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false, features = ["static","zlib"] }
+[target.'cfg(not(windows))'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+features = ["conda"]
+default-features = false
+
+[target.'cfg(windows)'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+default-features = false

--- a/enclone_args/Cargo.toml
+++ b/enclone_args/Cargo.toml
@@ -40,9 +40,13 @@ string_utils = { version = "0.1", git = "https://github.com/10XGenomics/rust-too
 vdj_ann = { version = "0.4", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 vector_utils = { version = "0.1", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 
-[target.'cfg(not(windows))'.dependencies]
-hdf5x = { git = "https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x", branch = "conda_nov2021_as_hdf5x", default-features=false, features = ["conda"] }
+[target.'cfg(not(windows))'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+features = ["conda"]
+default-features = false
 
-[target.'cfg(windows)'.dependencies]
-hdf5 = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false }
-hdf5-sys = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false, features = ["static","zlib"] }
+[target.'cfg(windows)'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+default-features = false

--- a/enclone_args/src/load_gex.rs
+++ b/enclone_args/src/load_gex.rs
@@ -6,11 +6,7 @@
 use crate::load_gex_core::load_gex;
 use enclone_core::defs::{EncloneControl, GexInfo};
 
-#[cfg(target_os = "windows")]
 use hdf5::Dataset;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::Dataset;
-
 use mirror_sparse_matrix::MirrorSparseMatrix;
 use rayon::prelude::*;
 use std::{collections::HashMap, time::Instant};
@@ -110,9 +106,6 @@ pub fn get_gex_info(ctl: &mut EncloneControl) -> Result<GexInfo, String> {
             {
                 let f = &h5_paths[i];
 
-                #[cfg(not(target_os = "windows"))]
-                let h = hdf5x::File::open(&f).unwrap();
-                #[cfg(target_os = "windows")]
                 let h = hdf5::File::open(&f).unwrap();
 
                 h5_data.push(Some(h.dataset("matrix/data").unwrap()));

--- a/enclone_core/Cargo.toml
+++ b/enclone_core/Cargo.toml
@@ -49,11 +49,17 @@ zstd = "0.9"
 
 [target.'cfg(not(windows))'.dependencies]
 tilde-expand = "0.1"
-hdf5x = { git = "https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x", branch = "conda_nov2021_as_hdf5x", default-features=false, features = ["conda"] }
 
-[target.'cfg(windows)'.dependencies]
-hdf5 = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false }
-hdf5-sys = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false, features = ["static","zlib"] }
+[target.'cfg(not(windows))'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+features = ["conda"]
+default-features = false
+
+[target.'cfg(windows)'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+default-features = false
 
 [build-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/enclone_core/src/defs.rs
+++ b/enclone_core/src/defs.rs
@@ -4,11 +4,7 @@ use crate::cell_color::CellColor;
 use crate::linear_condition::LinearCondition;
 use debruijn::dna_string::DnaString;
 use evalexpr::Node;
-
-#[cfg(target_os = "windows")]
 use hdf5::Dataset;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::Dataset;
 
 use io_utils::{open_for_read, path_exists};
 use mirror_sparse_matrix::MirrorSparseMatrix;

--- a/enclone_core/src/slurp.rs
+++ b/enclone_core/src/slurp.rs
@@ -2,10 +2,7 @@
 //
 // Slurp in needed data from an h5 file.
 
-#[cfg(target_os = "windows")]
 use hdf5::types::FixedAscii;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::types::FixedAscii;
 
 pub fn slurp_h5(
     h5_path: &str,
@@ -16,15 +13,9 @@ pub fn slurp_h5(
 ) -> Result<(), String> {
     // Read barcodes from the h5 file.
 
-    #[cfg(not(target_os = "windows"))]
-    let h = hdf5x::File::open(&h5_path).unwrap();
-    #[cfg(target_os = "windows")]
     let h = hdf5::File::open(&h5_path).unwrap();
     let barcode_loc = h.dataset("matrix/barcodes").unwrap();
 
-    #[cfg(not(target_os = "windows"))]
-    let barcodes0: Result<Vec<FixedAscii<18>>, hdf5x::Error> = barcode_loc.as_reader().read_raw();
-    #[cfg(target_os = "windows")]
     let barcodes0: Result<Vec<FixedAscii<18>>, hdf5::Error> = barcode_loc.as_reader().read_raw();
     if barcodes0.is_err() {
         return Err(format!(

--- a/enclone_print/Cargo.toml
+++ b/enclone_print/Cargo.toml
@@ -53,9 +53,13 @@ triple_accel = "0.4"
 vdj_ann = { version = "0.4", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 vector_utils = { version = "0.1", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 
-[target.'cfg(not(windows))'.dependencies]
-hdf5x = { git = "https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x", branch = "conda_nov2021_as_hdf5x", default-features=false, features = ["conda"] }
+[target.'cfg(not(windows))'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+features = ["conda"]
+default-features = false
 
-[target.'cfg(windows)'.dependencies]
-hdf5 = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false }
-hdf5-sys = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false, features = ["static","zlib"] }
+[target.'cfg(windows)'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+default-features = false

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -24,6 +24,7 @@ use enclone_core::mammalian_fixed_len::mammalian_fixed_len_peer_groups;
 use enclone_core::set_speakers::set_speakers;
 use enclone_proto::types::{Clonotype, DonorReferenceItem};
 use equiv::EquivRel;
+use hdf5::Reader;
 use qd::Double;
 use rayon::prelude::*;
 use std::cmp::max;
@@ -31,11 +32,6 @@ use std::collections::{HashMap, HashSet};
 use string_utils::TextUtils;
 use vdj_ann::refx::RefData;
 use vector_utils::{bin_member, bin_position, erase_if, next_diff12_3, unique_sort};
-
-#[cfg(target_os = "windows")]
-use hdf5::Reader;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::Reader;
 
 // Print clonotypes.  A key challenge here is to define the columns that represent shared
 // chains.  This is given below by the code that forms an equivalence relation on the CDR3_AAs.

--- a/enclone_print/src/print_utils2.rs
+++ b/enclone_print/src/print_utils2.rs
@@ -14,6 +14,7 @@ use enclone_core::median::median_f64;
 use enclone_proto::types::DonorReferenceItem;
 use enclone_vars::decode_arith;
 use expr_tools::{define_evalexpr_context, vars_of_node};
+use hdf5::Reader;
 use itertools::Itertools;
 use ndarray::s;
 use stats_utils::percent_ratio;
@@ -22,11 +23,6 @@ use string_utils::{stringme, strme, TextUtils};
 use vdj_ann::refx::RefData;
 use vector_utils::next_diff12_4;
 use vector_utils::{bin_member, bin_position, unique_sort};
-
-#[cfg(target_os = "windows")]
-use hdf5::Reader;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::Reader;
 
 // The following code creates a row in the enclone output table for a clonotype.  Simultaneously
 // it generates a row of parseable output.  And it does some other things that are not described

--- a/enclone_print/src/proc_lvar_auto.rs
+++ b/enclone_print/src/proc_lvar_auto.rs
@@ -5,10 +5,7 @@ use amino::{aa_seq, codon_to_aa};
 use enclone_core::defs::{ColInfo, EncloneControl, ExactClonotype, GexInfo, POUT_SEP};
 use enclone_core::median::{median_f64, rounded_median};
 use enclone_proto::types::DonorReferenceItem;
-#[cfg(target_os = "windows")]
 use hdf5::Reader;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::Reader;
 use itertools::Itertools;
 use ndarray::s;
 use regex::Regex;

--- a/enclone_ranger/Cargo.toml
+++ b/enclone_ranger/Cargo.toml
@@ -33,9 +33,13 @@ string_utils = { version = "0.1", git = "https://github.com/10XGenomics/rust-too
 vdj_ann = { version = "0.4", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 vector_utils = { version = "0.1", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 
-[target.'cfg(not(windows))'.dependencies]
-hdf5x = { git = "https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x", branch = "conda_nov2021_as_hdf5x", default-features=false, features = ["conda"] }
+[target.'cfg(not(windows))'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+features = ["conda"]
+default-features = false
 
-[target.'cfg(windows)'.dependencies]
-hdf5 = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false }
-hdf5-sys = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false, features = ["static","zlib"] }
+[target.'cfg(windows)'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+default-features = false

--- a/enclone_ranger/src/stop.rs
+++ b/enclone_ranger/src/stop.rs
@@ -3,13 +3,9 @@
 use enclone_core::defs::ColInfo;
 use enclone_core::enclone_structs::EncloneIntermediates;
 use enclone_print::print_clonotypes::print_clonotypes;
+use hdf5::Reader;
 use rayon::prelude::*;
 use std::collections::HashMap;
-
-#[cfg(target_os = "windows")]
-use hdf5::Reader;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::Reader;
 
 pub fn main_enclone_stop_ranger(mut inter: EncloneIntermediates) -> Result<(), String> {
     // Unpack inputs.

--- a/enclone_stuff/Cargo.toml
+++ b/enclone_stuff/Cargo.toml
@@ -41,9 +41,13 @@ tables = { version = "0.1", git = "https://github.com/10XGenomics/rust-toolbox.g
 vdj_ann = { version = "0.4", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 vector_utils = { version = "0.1", git = "https://github.com/10XGenomics/rust-toolbox.git", branch = "master" }
 
-[target.'cfg(not(windows))'.dependencies]
-hdf5x = { git = "https://github.com/DavidBJaffe/hdf5-rust-as-hdf5x", branch = "conda_nov2021_as_hdf5x", default-features=false, features = ["conda"] }
+[target.'cfg(not(windows))'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+features = ["conda"]
+default-features = false
 
-[target.'cfg(windows)'.dependencies]
-hdf5 = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false }
-hdf5-sys = { git = "https://github.com/CompRD/hdf5-rust", branch = "master", default-features=false, features = ["static","zlib"] }
+[target.'cfg(windows)'.dependencies.hdf5]
+git = "https://github.com/10XGenomics/hdf5-rust.git"
+branch = "conda_nov2021"
+default-features = false

--- a/enclone_stuff/src/fcell.rs
+++ b/enclone_stuff/src/fcell.rs
@@ -5,6 +5,7 @@
 use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype, GexInfo};
 use enclone_print::print_utils4::get_gex_matrix_entry;
 use evalexpr::{ContextWithMutableVariables, HashMapContext};
+use hdf5::Reader;
 use io_utils::{dir_list, path_exists};
 use ndarray::s;
 use rayon::prelude::*;
@@ -14,11 +15,6 @@ use std::time;
 use std::time::Instant;
 use string_utils::TextUtils;
 use vector_utils::{bin_position, erase_if};
-
-#[cfg(target_os = "windows")]
-use hdf5::Reader;
-#[cfg(not(target_os = "windows"))]
-use hdf5x::Reader;
 
 pub fn filter_by_fcell(
     ctl: &EncloneControl,

--- a/enclone_vars/src/export_code.rs
+++ b/enclone_vars/src/export_code.rs
@@ -724,9 +724,6 @@ pub fn export_code(level: usize) -> Vec<(String, String)> {
         use string_utils::*;
         use vdj_ann::refx::RefData;
         use vector_utils::*;
-        #[cfg(not(target_os = "windows"))]
-        use hdf5x::Reader;
-        #[cfg(target_os = "windows")]
         use hdf5::Reader;
 
         pub fn proc_lvar_auto(


### PR DESCRIPTION
Yeah, might not work on Windows.  We can address that properly later,
but for now the important thing is not breaking dependabot for
downstream users by having multiple sources for hdf5-sys.

Also, add a dependabot config.