### PR TITLE
More cleanups.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -7,4 +7,5 @@ linker = "x86_64-w64-mingw32-gcc"
 [target.'cfg(target_arch = "x86_64")']
 rustflags = [
   "-C", "target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt",
+  "-D", "unused",
 ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 env:
   CARGO_DENY_VERSION: "0.12.1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 target
-enclone_exec/test/inputs/version14/85679/outs/raw_feature_bc_matrix/matrix.bin
-enclone_exec/testx/outputs
-enclone-data
-enclone_visual/outputs
-enclone_visual/unofficial_images
-stamps/data_version_in_use
-stamps/last_sweep
-stamps/last_linktest
-crates.png
+*.o
+*.so
+*.swp
+*.DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.formatOnSave": true,
+    "files.insertFinalNewline": true,
+    "rust-analyzer.checkOnSave.allTargets": true,
+    "rust-analyzer.checkOnSave.command": "clippy",
+    "rust-analyzer.imports.merge.glob": false
+}

--- a/enclone/Cargo.toml
+++ b/enclone/Cargo.toml
@@ -15,6 +15,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
 edition = "2021"
 license-file = "LICENSE.txt"
 publish = false
+include = ["LICENSE.txt", "src/*.rs", "src/*.json"]
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml
 # in the root of the enclone repo.

--- a/enclone_core/Cargo.toml
+++ b/enclone_core/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 build = "build.rs"
 license-file = "LICENSE.txt"
 publish = false
+include = ["src/*.rs", "LICENSE.txt", "src/mammalian_fixed_len.table"]
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml
 # in the root of the enclone repo.

--- a/enclone_core/build.rs
+++ b/enclone_core/build.rs
@@ -27,6 +27,10 @@ fn main() {
         OS,
         ARCH
     );
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF");
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rustc-env=VERSION_STRING={}", version_string);
 }
 

--- a/enclone_proto/build.rs
+++ b/enclone_proto/build.rs
@@ -8,4 +8,5 @@ fn main() {
     let mut config = Config::new();
     config.type_attribute(".", "#[derive(::serde::Serialize, ::serde::Deserialize)]");
     config.compile_protos(&["types.proto"], &["."]).unwrap();
+    println!("cargo:rerun-if-changed=types.proto");
 }

--- a/enclone_vars/Cargo.toml
+++ b/enclone_vars/Cargo.toml
@@ -15,6 +15,7 @@ authors = ["""David Jaffe <david.jaffe@10xgenomics.com>,
 edition = "2021"
 license-file = "LICENSE.txt"
 publish = false
+exclude = ["src/bin/var_test.rs", "src/vars"]
 
 # Please do not edit crate versions within this file.  Instead edit the file master.toml
 # in the root of the enclone repo.


### PR DESCRIPTION
Add rerun-if-changed outputs for build.rs scripts so they don't have to
be rerun every time.

Add include or exclude directives in Cargo.toml to omit unnecessary
files.

Update .gitignore file.

Add basic vscode default settings.

Correct github workflow to run on main branch rather than master.

Remove empty `.git-credentials` file.