### PR TITLE
Fix range loops and unnecessary copies.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -130,7 +130,6 @@ jobs:
             -W clippy::enum_variant_names
             -W clippy::large-enum-variant
             -W clippy::missing_safety_doc
-            -A clippy::needless_range_loop
             -A clippy::type_complexity
             -A clippy::too_many_arguments
             -W clippy::result_unit_err

--- a/enclone/src/bin/traceback1.rs
+++ b/enclone/src/bin/traceback1.rs
@@ -41,8 +41,8 @@ fn test_traceback1() {
         let mut head = String::new();
         let lines = err.split('\n').collect::<Vec<&str>>();
         const MAX_LINES: usize = 60;
-        for i in 0..std::cmp::min(lines.len(), MAX_LINES) {
-            head += &format!("{}\n", lines[i]);
+        for &line in lines.iter().take(MAX_LINES) {
+            head += &format!("{}\n", line);
         }
         eprint!(
             "\n▓▓▓ test_traceback1 failed because did not find {} as expected;\n\n\

--- a/enclone/src/info.rs
+++ b/enclone/src/info.rs
@@ -19,8 +19,8 @@ use vector_utils::unique_sort;
 pub fn build_info(
     refdata: &RefData,
     ctl: &EncloneControl,
-    exact_clonotypes: &mut Vec<ExactClonotype>,
-    fate: &mut [HashMap<String, String>],
+    exact_clonotypes: &mut [ExactClonotype],
+    fate: &mut [HashMap<String, &str>],
 ) -> Vec<CloneInfo> {
     // Build info about clonotypes.  We create a data structure info.
     // An entry in info is a clonotype having appropriate properties.
@@ -33,10 +33,10 @@ pub fn build_info(
         usize,
         Vec<CloneInfo>,
         ExactClonotype,
-        Vec<(usize, String, String)>,
+        Vec<(usize, String, &'static str)>,
     )>::new();
-    for i in 0..exact_clonotypes.len() {
-        results.push((i, Vec::new(), exact_clonotypes[i].clone(), Vec::new()));
+    for (i, ct) in exact_clonotypes.iter().enumerate() {
+        results.push((i, Vec::new(), ct.clone(), Vec::new()));
     }
     results.par_iter_mut().for_each(|res| {
         let i = res.0;
@@ -142,9 +142,9 @@ pub fn build_info(
                 let mut mis = Vec::<(usize, usize, Vec<u8>)>::new();
                 for j in ins_pos_low..ins_pos_high {
                     let mut y = Vec::<u8>::new();
-                    for k in 0..aa_full.len() {
+                    for (k, &aa) in aa_full.iter().enumerate() {
                         if k < j || k >= j + ins_len_aa {
-                            y.push(aa_full[k]);
+                            y.push(aa);
                         }
                     }
                     let mut m = 0;
@@ -323,7 +323,7 @@ pub fn build_info(
                 res.3.push((
                     ex.clones[j][0].dataset_index,
                     ex.clones[j][0].barcode.clone(),
-                    "failed IMPROPER filter".to_string(),
+                    "failed IMPROPER filter",
                 ));
             }
         }
@@ -361,7 +361,7 @@ pub fn build_info(
         info.append(&mut results[i].1);
         exact_clonotypes[i] = results[i].2.clone();
         for j in 0..results[i].3.len() {
-            fate[results[i].3[j].0].insert(results[i].3[j].1.clone(), results[i].3[j].2.clone());
+            fate[results[i].3[j].0].insert(results[i].3[j].1.clone(), results[i].3[j].2);
         }
     }
 

--- a/enclone/src/innate.rs
+++ b/enclone/src/innate.rs
@@ -19,11 +19,11 @@ pub fn species(refdata: &RefData) -> &'static str {
         }
     }
     const K: usize = 60;
-    let mut kmers = Vec::<Vec<u8>>::new();
-    for i in 0..my_trac.len() {
-        if my_trac[i].len() >= K {
-            for j in 0..=my_trac[i].len() - K {
-                kmers.push(my_trac[i][j..j + K].to_vec());
+    let mut kmers = Vec::<&[u8]>::new();
+    for tr in &my_trac {
+        if tr.len() >= K {
+            for j in 0..=tr.len() - K {
+                kmers.push(&tr[j..j + K]);
             }
         }
     }
@@ -131,7 +131,7 @@ pub fn species(refdata: &RefData) -> &'static str {
         // Test the kmers.
 
         for i in 0..=trac.len() - K {
-            let kmer = trac[i..i + K].to_vec();
+            let kmer = &trac[i..i + K];
             if bin_member(&kmers, &kmer) {
                 count += 1;
             }
@@ -173,19 +173,19 @@ pub fn mark_innate(refdata: &RefData, ex: &mut Vec<ExactClonotype>) {
     let species = species(refdata);
     let inkt_cdr3 = innate_cdr3(species, "iNKT");
     let mait_cdr3 = innate_cdr3(species, "MAIT");
-    for i in 0..ex.len() {
+    for e in ex {
         let (mut have_mait_tra, mut have_mait_trb) = (false, false);
         let (mut have_mait_tra_cdr3, mut have_mait_trb_cdr3) = (false, false);
         let (mut have_inkt_tra, mut have_inkt_trb) = (false, false);
         let (mut have_inkt_tra_cdr3, mut have_inkt_trb_cdr3) = (false, false);
-        for j in 0..ex[i].share.len() {
-            let mut vname = refdata.name[ex[i].share[j].v_ref_id].clone();
+        for share in &e.share {
+            let mut vname = refdata.name[share.v_ref_id].as_str();
             if vname.contains('*') {
-                vname = vname.before("*").to_string();
+                vname = vname.before("*");
             }
-            let mut jname = refdata.name[ex[i].share[j].j_ref_id].clone();
+            let mut jname = refdata.name[share.j_ref_id].as_str();
             if jname.contains('*') {
-                jname = jname.before("*").to_string();
+                jname = jname.before("*");
             }
             if species == "human" {
                 if vname == "TRAV10" && jname == "TRAJ18" {
@@ -220,31 +220,31 @@ pub fn mark_innate(refdata: &RefData, ex: &mut Vec<ExactClonotype>) {
                     have_inkt_trb = true;
                 }
             }
-            if ex[i].share[j].left {
-                if bin_member(&inkt_cdr3, &ex[i].share[j].cdr3_aa) {
+            if share.left {
+                if bin_member(&inkt_cdr3, &share.cdr3_aa) {
                     have_inkt_trb_cdr3 = true;
                 }
-                if bin_member(&mait_cdr3, &ex[i].share[j].cdr3_aa) {
+                if bin_member(&mait_cdr3, &share.cdr3_aa) {
                     have_mait_trb_cdr3 = true;
                 }
             } else {
-                if bin_member(&inkt_cdr3, &ex[i].share[j].cdr3_aa) {
+                if bin_member(&inkt_cdr3, &share.cdr3_aa) {
                     have_inkt_tra_cdr3 = true;
                 }
-                if bin_member(&mait_cdr3, &ex[i].share[j].cdr3_aa) {
+                if bin_member(&mait_cdr3, &share.cdr3_aa) {
                     have_mait_tra_cdr3 = true;
                 }
             }
         }
-        for j in 0..ex[i].share.len() {
-            ex[i].share[j].inkt_alpha_chain_gene_match = have_inkt_tra;
-            ex[i].share[j].inkt_alpha_chain_junction_match = have_inkt_tra_cdr3;
-            ex[i].share[j].inkt_beta_chain_gene_match = have_inkt_trb;
-            ex[i].share[j].inkt_beta_chain_junction_match = have_inkt_trb_cdr3;
-            ex[i].share[j].mait_alpha_chain_gene_match = have_mait_tra;
-            ex[i].share[j].mait_alpha_chain_junction_match = have_mait_tra_cdr3;
-            ex[i].share[j].mait_beta_chain_gene_match = have_mait_trb;
-            ex[i].share[j].mait_beta_chain_junction_match = have_mait_trb_cdr3;
+        for share in e.share.iter_mut() {
+            share.inkt_alpha_chain_gene_match = have_inkt_tra;
+            share.inkt_alpha_chain_junction_match = have_inkt_tra_cdr3;
+            share.inkt_beta_chain_gene_match = have_inkt_trb;
+            share.inkt_beta_chain_junction_match = have_inkt_trb_cdr3;
+            share.mait_alpha_chain_gene_match = have_mait_tra;
+            share.mait_alpha_chain_junction_match = have_mait_tra_cdr3;
+            share.mait_beta_chain_gene_match = have_mait_trb;
+            share.mait_beta_chain_junction_match = have_mait_trb_cdr3;
         }
     }
 }

--- a/enclone/src/join.rs
+++ b/enclone/src/join.rs
@@ -146,32 +146,32 @@ pub fn join_exacts(
             // Form the equivalence relation implied by the potential joins.
 
             let mut eq: EquivRel = EquivRel::new((j - i) as i32);
-            for pj in 0..pot.len() {
-                let (k1, k2) = (pot[pj].k1, pot[pj].k2);
+            for pot in &pot {
+                let (k1, k2) = (pot.k1, pot.k2);
                 eq.join((k1 - i) as i32, (k2 - i) as i32);
             }
 
             // Impose a higher bar on joins that involve only two cells. (not documented)
 
             let mut to_pot = vec![Vec::<usize>::new(); j - i];
-            for pj in 0..pot.len() {
-                let k1 = pot[pj].k1;
+            for (pj, pot) in pot.iter().enumerate() {
+                let k1 = pot.k1;
                 to_pot[k1 - i].push(pj);
             }
             let mut to_delete = vec![false; pot.len()];
             let mut reps = Vec::<i32>::new();
             eq.orbit_reps(&mut reps);
-            for s in 0..reps.len() {
+            for rep in reps {
                 // Examine a potential orbit.
 
                 let mut x = Vec::<i32>::new();
-                eq.orbit(reps[s], &mut x);
+                eq.orbit(rep, &mut x);
 
                 // Count the number of cells in the orbit.
 
                 let mut ncells = 0;
-                for t in 0..x.len() {
-                    let k = x[t] as usize + i;
+                for &t in &x {
+                    let k = t as usize + i;
                     let mult = exact_clonotypes[info[k].clonotype_index].ncells();
                     ncells += mult;
                 }
@@ -205,23 +205,23 @@ pub fn join_exacts(
         // Analyze potential joins.
 
         let mut eq: EquivRel = EquivRel::new((j - i) as i32);
-        for pj in 0..pot.len() {
-            let k1 = pot[pj].k1;
-            let k2 = pot[pj].k2;
-            let nrefs = pot[pj].nrefs;
-            let cd = pot[pj].cd;
-            let diffs = pot[pj].diffs;
-            let bcs1 = &pot[pj].bcs1;
-            let bcs2 = &pot[pj].bcs2;
-            let shares = &pot[pj].shares;
-            let indeps = &pot[pj].indeps;
-            let shares_details = &pot[pj].shares_details;
-            let share_pos_v = &pot[pj].share_pos_v;
-            let share_pos_j = &pot[pj].share_pos_j;
-            let score = pot[pj].score;
-            let err = pot[pj].err;
-            let p1 = pot[pj].p1;
-            let mult = pot[pj].mult;
+        for pj in pot {
+            let k1 = pj.k1;
+            let k2 = pj.k2;
+            let nrefs = pj.nrefs;
+            let cd = pj.cd;
+            let diffs = pj.diffs;
+            let bcs1 = &pj.bcs1;
+            let bcs2 = &pj.bcs2;
+            let shares = &pj.shares;
+            let indeps = &pj.indeps;
+            let shares_details = &pj.shares_details;
+            let share_pos_v = &pj.share_pos_v;
+            let share_pos_j = &pj.share_pos_j;
+            let score = pj.score;
+            let err = pj.err;
+            let p1 = pj.p1;
+            let mult = pj.mult;
 
             // Do nothing if join could have no effect on equivalence relation.
 
@@ -505,9 +505,9 @@ pub fn join_exacts(
             fwriteln!(
                 log,
                 "computed using k = {}, d = {}, n = {}",
-                pot[pj].k,
-                pot[pj].d,
-                pot[pj].n
+                pj.k,
+                pj.d,
+                pj.n
             );
             fwriteln!(
                 log,
@@ -602,9 +602,9 @@ pub fn join_exacts(
     results.par_iter_mut().for_each(joinf);
 
     ctl.perf_stats(&timer2, "in main part of join");
-    for l in 0..results.len() {
-        for j in 0..results[l].5.len() {
-            raw_joins.push((results[l].5[j].0 as i32, results[l].5[j].1 as i32));
+    for r in &results {
+        for &j in &r.5 {
+            raw_joins.push((j.0 as i32, j.1 as i32));
         }
     }
     finish_join(ctl, info, &results, join_info)

--- a/enclone/src/join2.rs
+++ b/enclone/src/join2.rs
@@ -27,14 +27,14 @@ pub fn finish_join(
 
     let (mut joins, mut errors) = (0, 0);
     let timer3 = Instant::now();
-    for l in 0..results.len() {
-        joins += results[l].2;
-        errors += results[l].3;
-        for i in 0..results[l].4.len() {
-            let u1 = results[l].4[i].0;
-            let u2 = results[l].4[i].1;
-            let err = results[l].4[i].2;
-            let log = results[l].4[i].3.clone();
+    for r in results {
+        joins += r.2;
+        errors += r.3;
+        for i in &r.4 {
+            let u1 = i.0;
+            let u2 = i.1;
+            let err = i.2;
+            let log = i.3.clone();
             join_info.push((u1, u2, err, log));
         }
     }
@@ -48,9 +48,9 @@ pub fn finish_join(
     // Make equivalence relation.
 
     let mut eq: EquivRel = EquivRel::new(info.len() as i32);
-    for l in 0..results.len() {
-        for j in 0..results[l].5.len() {
-            eq.join(results[l].5[j].0 as i32, results[l].5[j].1 as i32);
+    for r in results {
+        for j in &r.5 {
+            eq.join(j.0 as i32, j.1 as i32);
         }
     }
 
@@ -58,8 +58,7 @@ pub fn finish_join(
     // clonotypes into two-chain clonotypes.
 
     let mut ox = Vec::<(usize, i32)>::new();
-    for i in 0..info.len() {
-        let x: &CloneInfo = &info[i];
+    for (i, x) in info.iter().enumerate() {
         ox.push((x.clonotype_id, eq.class_id(i as i32)));
     }
     ox.sort_unstable();
@@ -84,9 +83,9 @@ pub fn finish_join(
     if white {
         let mut bads = 0;
         let mut denom = 0;
-        for i in 0..results.len() {
-            bads += results[i].2;
-            denom += results[i].3;
+        for r in results {
+            bads += r.2;
+            denom += r.3;
         }
         let bad_rate = percent_ratio(bads, denom);
         println!("whitelist contamination rate = {:.2}%", bad_rate);

--- a/enclone/src/join_core.rs
+++ b/enclone/src/join_core.rs
@@ -8,16 +8,16 @@ use qd::Double;
 use std::collections::HashMap;
 use vdj_ann::refx::RefData;
 
-pub fn join_core(
+pub fn join_core<'a>(
     is_bcr: bool,
     i: usize,
     j: usize,
     ctl: &EncloneControl,
     exact_clonotypes: &[ExactClonotype],
     info: &[CloneInfo],
-    to_bc: &HashMap<(usize, usize), Vec<String>>,
+    to_bc: &'a HashMap<(usize, usize), Vec<String>>,
     sr: &[Vec<Double>],
-    pot: &mut Vec<PotentialJoin>,
+    pot: &mut Vec<PotentialJoin<'a>>,
     refdata: &RefData,
     dref: &[DonorReferenceItem],
 ) {

--- a/enclone/src/misc3.rs
+++ b/enclone/src/misc3.rs
@@ -136,40 +136,40 @@ pub fn study_consensus(
             );
             let _len = share[z].seq.len();
             let mut lefts = Vec::<Vec<u8>>::new();
-            for m in 0..clones.len() {
-                let start = clones[m][z].v_start;
-                let mut x = clones[m][z].full_seq[0..start].to_vec();
+            for clone in clones {
+                let start = clone[z].v_start;
+                let mut x = clone[z].full_seq[0..start].to_vec();
                 x.reverse();
-                lefts.push(x.to_vec());
+                lefts.push(x);
             }
             let mut rutrs = Vec::<Vec<u8>>::new();
-            for i in 0..utr_ids.len() {
-                let mut x = refdata.refs[utr_ids[i]].to_string().as_bytes().to_vec();
+            for &id in &utr_ids {
+                let mut x = refdata.refs[id].to_string().as_bytes().to_vec();
                 x.reverse();
-                rutrs.push(x.to_vec());
+                rutrs.push(x);
             }
             let mut minlen = 1_000_000;
             let mut maxlen = 0;
-            for i in 0..lefts.len() {
-                minlen = min(minlen, lefts[i].len());
-                maxlen = max(maxlen, lefts[i].len());
+            for left in &lefts {
+                minlen = min(minlen, left.len());
+                maxlen = max(maxlen, left.len());
             }
-            for i in 0..rutrs.len() {
-                minlen = min(minlen, rutrs[i].len());
-                maxlen = max(maxlen, rutrs[i].len());
+            for r in &rutrs {
+                minlen = min(minlen, r.len());
+                maxlen = max(maxlen, r.len());
             }
             let mut dots = Vec::<u8>::new();
             let mut diffs = 0;
             for j in 0..maxlen {
                 let mut bases = Vec::<u8>::new();
-                for i in 0..lefts.len() {
-                    if j < lefts[i].len() {
-                        bases.push(lefts[i][j]);
+                for left in &lefts {
+                    if j < left.len() {
+                        bases.push(left[j]);
                     }
                 }
-                for i in 0..rutrs.len() {
-                    if j < rutrs[i].len() {
-                        bases.push(rutrs[i][j]);
+                for r in &rutrs {
+                    if j < r.len() {
+                        bases.push(r[j]);
                     }
                 }
                 let mut diff = false;
@@ -186,14 +186,14 @@ pub fn study_consensus(
                 }
             }
             fwriteln!(log, "     {}", strme(&dots));
-            for i in 0..rutrs.len() {
-                fwriteln!(log, " U = {}", strme(&rutrs[i]));
+            for r in rutrs {
+                fwriteln!(log, " U = {}", strme(&r));
             }
-            for i in 0..lefts.len() {
+            for (i, left) in lefts.iter().enumerate() {
                 if i < 9 {
                     fwrite!(log, " ");
                 }
-                fwriteln!(log, "{} = {}", i + 1, strme(&lefts[i]));
+                fwriteln!(log, "{} = {}", i + 1, strme(left));
             }
             if !(minlen == maxlen && diffs == 0 && utr_ids.len() == 1) {
                 print!("{}", strme(&log));
@@ -251,26 +251,26 @@ pub fn study_consensus(
                 .collect::<Vec<_>>();
             let mut minlen = 1_000_000;
             let mut maxlen = 0;
-            for i in 0..rights.len() {
-                minlen = min(minlen, rights[i].len());
-                maxlen = max(maxlen, rights[i].len());
+            for r in &rights {
+                minlen = min(minlen, r.len());
+                maxlen = max(maxlen, r.len());
             }
-            for i in 0..rights.len() {
-                minlen = min(minlen, rights[i].len());
-                maxlen = max(maxlen, rights[i].len());
+            for r in &rights {
+                minlen = min(minlen, r.len());
+                maxlen = max(maxlen, r.len());
             }
             let mut dots = Vec::<u8>::new();
             let mut diffs = 0;
             for j in 0..maxlen {
                 let mut bases = Vec::<u8>::new();
-                for i in 0..rights.len() {
-                    if j < rights[i].len() {
-                        bases.push(rights[i][j]);
+                for r in &rights {
+                    if j < r.len() {
+                        bases.push(r[j]);
                     }
                 }
-                for i in 0..rconst.len() {
-                    if j < rconst[i].len() {
-                        bases.push(rconst[i][j]);
+                for r in &rconst {
+                    if j < r.len() {
+                        bases.push(r[j]);
                     }
                 }
                 let mut diff = false;

--- a/enclone/src/subset_json.rs
+++ b/enclone/src/subset_json.rs
@@ -4,6 +4,7 @@
 // in a given sorted vector.
 
 use io_utils::open_userfile_for_read;
+use std::fmt::Write;
 use std::io::BufRead;
 use string_utils::TextUtils;
 use vector_utils::bin_member;
@@ -20,8 +21,8 @@ pub fn subset_all_contig_annotations_json(filename: &str, barcodes: &[String]) -
         }
         if s == "]" {
             if keep {
-                for i in 0..lines.len() {
-                    x += &format!("{}\n", lines[i]);
+                for line in &lines {
+                    writeln!(&mut x, "{}", line).unwrap();
                 }
             }
             break;
@@ -32,8 +33,8 @@ pub fn subset_all_contig_annotations_json(filename: &str, barcodes: &[String]) -
             keep = bin_member(barcodes, &t.to_string());
         } else if s.starts_with("    }") {
             if keep {
-                for i in 0..lines.len() {
-                    x += &format!("{}\n", lines[i]);
+                for line in &lines {
+                    writeln!(&mut x, "{}", line).unwrap();
                 }
             }
             lines.clear();

--- a/enclone_args/src/lib.rs
+++ b/enclone_args/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
+#![allow(clippy::needless_range_loop)]
 
 use io_utils::path_exists;
 
@@ -16,34 +17,27 @@ pub mod read_json;
 
 // parse_csv_pure: same as parse_csv, but don't strip out quotes
 
-pub fn parse_csv_pure(x: &str) -> Vec<String> {
-    let mut y = Vec::<String>::new();
-    let mut w = Vec::<char>::new();
-    for c in x.chars() {
-        w.push(c);
-    }
+pub fn parse_csv_pure(x: &str) -> Vec<&str> {
+    let w = x.char_indices().collect::<Vec<_>>();
+    let mut y = Vec::new();
     let (mut quotes, mut i) = (0, 0);
     while i < w.len() {
         let mut j = i;
         while j < w.len() {
-            if quotes % 2 == 0 && w[j] == ',' {
+            if quotes % 2 == 0 && w[j].1 == ',' {
                 break;
             }
-            if w[j] == '"' {
+            if w[j].1 == '"' {
                 quotes += 1;
             }
             j += 1;
         }
         let (start, stop) = (i, j);
-        let mut s = String::new();
-        for m in start..stop {
-            s.push(w[m]);
-        }
-        y.push(s);
+        y.push(&x[w[start].0..w[stop].0]);
         i = j + 1;
     }
-    if !w.is_empty() && *w.last().unwrap() == ',' {
-        y.push(String::new());
+    if !w.is_empty() && w.last().unwrap().1 == ',' {
+        y.push("");
     }
     y
 }

--- a/enclone_core/src/align_to_vdj_ref.rs
+++ b/enclone_core/src/align_to_vdj_ref.rs
@@ -40,8 +40,8 @@ pub fn zero_one(
     {
         let mut rpos = 0;
         let mut zo = Vec::<u8>::new();
-        for m in 0..ops.len() {
-            match ops[m] {
+        for &om in ops {
+            match om {
                 Match => {
                     if rpos >= start && rpos < stop {
                         zo.push(1);
@@ -83,15 +83,14 @@ pub fn zero_one(
 
 pub fn match_bit_score(zos: &Vec<Vec<u8>>) -> f64 {
     let mut bits = 0.0_f64;
-    for i in 0..zos.len() {
-        let zo = &zos[i];
+    for zo in zos {
         for start in 0..zo.len() {
             for stop in start + 1..=zo.len() {
                 let b = &zo[start..stop];
                 let n = b.len();
                 let mut k = 0; // number of mismatches
-                for z in 0..n {
-                    if b[z] == 0 {
+                for &bz in b {
+                    if bz == 0 {
                         k += 1;
                     }
                 }
@@ -276,25 +275,25 @@ pub fn align_to_vdj_ref(
     scoring.yclip_suffix = 0;
     let mut aligner = Aligner::with_scoring(scoring);
     let mut gap_open_fn = vec![0_i32; concat.len() + 1];
-    for j in 1..=concat.len() {
-        if j as usize == vref.len()
-            || j as usize == vref.len() + dref.len()
-            || j as usize == vref.len() + dref.len() + d2ref.len()
+    for (j, gap) in gap_open_fn.iter_mut().enumerate().skip(1) {
+        if j == vref.len()
+            || j == vref.len() + dref.len()
+            || j == vref.len() + dref.len() + d2ref.len()
         {
-            gap_open_fn[j] = gap_open_at_boundary;
+            *gap = gap_open_at_boundary;
         } else {
-            gap_open_fn[j] = gap_open;
+            *gap = gap_open;
         }
     }
     let mut gap_extend_fn = vec![0_i32; concat.len() + 1];
-    for j in 1..=concat.len() {
-        if j as usize == vref.len()
-            || j as usize == vref.len() + dref.len()
-            || j as usize == vref.len() + dref.len() + d2ref.len()
+    for (j, gap) in gap_extend_fn.iter_mut().enumerate().skip(1) {
+        if j == vref.len()
+            || j == vref.len() + dref.len()
+            || j == vref.len() + dref.len() + d2ref.len()
         {
-            gap_extend_fn[j] = gap_extend_at_boundary;
+            *gap = gap_extend_at_boundary;
         } else {
-            gap_extend_fn[j] = gap_extend;
+            *gap = gap_extend;
         }
     }
     let mut al = aligner.custom_with_gap_fns(seq, &concat, &gap_open_fn, &gap_extend_fn);

--- a/enclone_core/src/combine_group_pics.rs
+++ b/enclone_core/src/combine_group_pics.rs
@@ -21,25 +21,26 @@ pub fn combine_group_pics(
     let mut done = false;
     if noprint && parseable_stdouth && !group_pics.is_empty() {
         let mut rows = Vec::<Vec<String>>::new();
-        for i in 0..group_pics.len() {
-            let r: Vec<String> = group_pics[i].split('\n').map(str::to_owned).collect();
-            for j in 0..r.len() - 1 {
-                let s = r[j].split('\t').map(str::to_owned).collect();
+        for pic in group_pics {
+            let r = pic.split('\n');
+            for rj in r.skip(1) {
+                let s = rj.split('\t').map(str::to_owned).collect();
                 rows.push(s);
             }
         }
         let mut same = true;
         let n = rows[0].len();
-        for i in 1..rows.len() {
-            if rows[i].len() != n {
+        for row in rows.iter().skip(1) {
+            if row.len() != n {
                 same = false;
             }
         }
         if same {
-            let mut justify = Vec::<u8>::new();
-            for x in rows[0].iter() {
-                justify.push(justification(x));
-            }
+            let justify = rows[0]
+                .iter()
+                .map(String::as_str)
+                .map(justification)
+                .collect();
             print_tabular(&mut glog, &rows, 2, Some(justify));
             done = true;
         }

--- a/enclone_core/src/defs.rs
+++ b/enclone_core/src/defs.rs
@@ -942,14 +942,14 @@ pub const POUT_SEP: &str = "\x07";
 // Potential join structure.
 
 #[derive(Default)]
-pub struct PotentialJoin {
+pub struct PotentialJoin<'a> {
     pub k1: usize,
     pub k2: usize,
     pub nrefs: usize,
     pub cd: isize,
     pub diffs: usize,
-    pub bcs1: Vec<String>,
-    pub bcs2: Vec<String>,
+    pub bcs1: Vec<&'a str>,
+    pub bcs2: Vec<&'a str>,
     pub shares: Vec<isize>,
     pub indeps: Vec<isize>,
     pub shares_details: Vec<Vec<usize>>,

--- a/enclone_core/src/enclone_structs.rs
+++ b/enclone_core/src/enclone_structs.rs
@@ -57,7 +57,7 @@ pub struct EncloneExacts {
     pub join_info: Vec<(usize, usize, bool, Vec<u8>)>,
     pub drefs: Vec<DonorReferenceItem>,
     pub sr: Vec<Vec<Double>>,
-    pub fate: Vec<HashMap<String, String>>, // GETS MODIFIED SUBSEQUENTLY
+    pub fate: Vec<HashMap<String, &'static str>>, // GETS MODIFIED SUBSEQUENTLY
     pub is_bcr: bool,
     pub allele_data: AlleleData,
 }

--- a/enclone_core/src/mammalian_fixed_len.rs
+++ b/enclone_core/src/mammalian_fixed_len.rs
@@ -9,45 +9,50 @@ use vdj_ann::vdj_features::{cdr1_start, cdr2_start, cdr3_start, fr1_start, fr2_s
 
 // {chain, feature, len, {{(count, amino_acid)}}}
 
-pub fn mammalian_fixed_len() -> Vec<(String, String, usize, Vec<Vec<(u32, u8)>>)> {
-    let mut p = Vec::<(String, String, usize, Vec<Vec<(u32, u8)>>)>::new();
-    let x = include_str!("mammalian_fixed_len.table");
-    for line in x.lines() {
-        let y = line.split(',').collect::<Vec<&str>>();
-        let mut pp = Vec::<Vec<(u32, u8)>>::new();
-        let z = y[3].split('+').collect::<Vec<&str>>();
-        for i in 0..z.len() {
-            let mut ppp = Vec::<(u32, u8)>::new();
-            let w = z[i].split('/').collect::<Vec<&str>>();
-            for j in 0..w.len() {
-                ppp.push((
-                    w[j].before(":").force_usize() as u32,
-                    w[j].after(":").as_bytes()[0] as u8,
-                ));
-            }
-            pp.push(ppp);
-        }
-        p.push((y[0].to_string(), y[1].to_string(), y[2].force_usize(), pp));
-    }
-    p
+pub fn mammalian_fixed_len() -> Vec<(&'static str, &'static str, usize, Vec<Vec<(u32, u8)>>)> {
+    const X: &str = include_str!("mammalian_fixed_len.table");
+    X.lines()
+        .map(|line| {
+            let mut y = line.splitn(5, ',');
+            (
+                y.next().unwrap(),
+                y.next().unwrap(),
+                y.next().unwrap().force_usize(),
+                y.next()
+                    .unwrap()
+                    .split('+')
+                    .map(|zi| {
+                        zi.split('/')
+                            .map(|wj| {
+                                (
+                                    wj.before(":").force_usize() as u32,
+                                    wj.after(":").as_bytes()[0] as u8,
+                                )
+                            })
+                            .collect()
+                    })
+                    .collect(),
+            )
+        })
+        .collect()
 }
 
 // Calculate peer groups for each V segment reference sequence.
 
 pub fn mammalian_fixed_len_peer_groups(refdata: &RefData) -> Vec<Vec<(usize, u8, u32)>> {
-    let mut pg = vec![Vec::<(usize, u8, u32)>::new(); refdata.refs.len()];
     let m = mammalian_fixed_len();
-    let mut start = HashMap::<(String, String), usize>::new();
-    let mut stop = HashMap::<(String, String), usize>::new();
-    for chain in ["IGH", "IGK", "IGL", "TRA", "TRB"].iter() {
-        for feature in ["fwr1", "cdr1", "fwr2", "cdr2", "fwr3"].iter() {
-            let low = m.lower_bound_by_key(&(*chain, *feature), |(a, b, _c, _d)| (a, b));
-            let high = m.upper_bound_by_key(&(*chain, *feature), |(a, b, _c, _d)| (a, b));
-            start.insert((chain.to_string(), feature.to_string()), low);
-            stop.insert((chain.to_string(), feature.to_string()), high);
+    let mut start = HashMap::<(&str, &str), usize>::new();
+    let mut stop = HashMap::<(&str, &str), usize>::new();
+    for chain in ["IGH", "IGK", "IGL", "TRA", "TRB"] {
+        for feature in ["fwr1", "cdr1", "fwr2", "cdr2", "fwr3"] {
+            let low = m.lower_bound_by_key(&(chain, feature), |(a, b, _c, _d)| (a, b));
+            let high = m.upper_bound_by_key(&(chain, feature), |(a, b, _c, _d)| (a, b));
+            start.insert((chain, feature), low);
+            stop.insert((chain, feature), high);
         }
     }
-    for i in 0..refdata.refs.len() {
+    let mut pg = vec![Vec::<(usize, u8, u32)>::new(); refdata.refs.len()];
+    for (i, pgi) in pg.iter_mut().enumerate() {
         if refdata.is_v(i) {
             let aa = aa_seq(&refdata.refs[i].to_ascii_vec(), 0);
             let rtype = refdata.rtype[i];
@@ -72,15 +77,13 @@ pub fn mammalian_fixed_len_peer_groups(refdata: &RefData) -> Vec<Vec<(usize, u8,
             let cs3 = cdr3_start(&aa, chain_type, false);
             if let Some(cs1) = cs1 {
                 if fs1 < cs1 {
-                    let x1 = start[&(chain_type.to_string(), "fwr1".to_string())];
-                    let x2 = stop[&(chain_type.to_string(), "fwr1".to_string())];
+                    let x1 = start[&(chain_type, "fwr1")];
+                    let x2 = stop[&(chain_type, "fwr1")];
                     let len = cs1 - fs1;
-                    for x in x1..x2 {
-                        if m[x].2 == len {
-                            for j in 0..len {
-                                for k in 0..m[x].3[j].len() {
-                                    pg[i].push((fs1 + j, m[x].3[j][k].1, m[x].3[j][k].0));
-                                }
+                    for mx in &m[x1..x2] {
+                        if mx.2 == len {
+                            for (j, mj) in mx.3.iter().take(len).enumerate() {
+                                pgi.extend(mj.iter().map(|mjk| (fs1 + j, mjk.1, mjk.0)));
                             }
                         }
                     }
@@ -88,15 +91,13 @@ pub fn mammalian_fixed_len_peer_groups(refdata: &RefData) -> Vec<Vec<(usize, u8,
             }
             if let (Some(cs1), Some(fs2)) = (cs1, fs2) {
                 if cs1 < fs2 {
-                    let x1 = start[&(chain_type.to_string(), "cdr1".to_string())];
-                    let x2 = stop[&(chain_type.to_string(), "cdr1".to_string())];
+                    let x1 = start[&(chain_type, "cdr1")];
+                    let x2 = stop[&(chain_type, "cdr1")];
                     let len = fs2 - cs1;
-                    for x in x1..x2 {
-                        if m[x].2 == len {
-                            for j in 0..len {
-                                for k in 0..m[x].3[j].len() {
-                                    pg[i].push((cs1 + j, m[x].3[j][k].1, m[x].3[j][k].0));
-                                }
+                    for mx in &m[x1..x2] {
+                        if mx.2 == len {
+                            for (j, mj) in mx.3.iter().take(len).enumerate() {
+                                pgi.extend(mj.iter().map(|mjk| (cs1 + j, mjk.1, mjk.0)));
                             }
                         }
                     }
@@ -104,15 +105,13 @@ pub fn mammalian_fixed_len_peer_groups(refdata: &RefData) -> Vec<Vec<(usize, u8,
             }
             if let (Some(fs2), Some(cs2)) = (fs2, cs2) {
                 if fs2 < cs2 {
-                    let x1 = start[&(chain_type.to_string(), "fwr2".to_string())];
-                    let x2 = stop[&(chain_type.to_string(), "fwr2".to_string())];
+                    let x1 = start[&(chain_type, "fwr2")];
+                    let x2 = stop[&(chain_type, "fwr2")];
                     let len = cs2 - fs2;
-                    for x in x1..x2 {
-                        if m[x].2 == len {
-                            for j in 0..len {
-                                for k in 0..m[x].3[j].len() {
-                                    pg[i].push((fs2 + j, m[x].3[j][k].1, m[x].3[j][k].0));
-                                }
+                    for mx in &m[x1..x2] {
+                        if mx.2 == len {
+                            for (j, mj) in mx.3.iter().take(len).enumerate() {
+                                pgi.extend(mj.iter().map(|mjk| (fs2 + j, mjk.1, mjk.0)));
                             }
                         }
                     }
@@ -120,15 +119,13 @@ pub fn mammalian_fixed_len_peer_groups(refdata: &RefData) -> Vec<Vec<(usize, u8,
             }
             if let (Some(cs2), Some(fs3)) = (cs2, fs3) {
                 if cs2 < fs3 {
-                    let x1 = start[&(chain_type.to_string(), "cdr2".to_string())];
-                    let x2 = stop[&(chain_type.to_string(), "cdr2".to_string())];
+                    let x1 = start[&(chain_type, "cdr2")];
+                    let x2 = stop[&(chain_type, "cdr2")];
                     let len = fs3 - cs2;
-                    for x in x1..x2 {
-                        if m[x].2 == len {
-                            for j in 0..len {
-                                for k in 0..m[x].3[j].len() {
-                                    pg[i].push((cs2 + j, m[x].3[j][k].1, m[x].3[j][k].0));
-                                }
+                    for mx in &m[x1..x2] {
+                        if mx.2 == len {
+                            for (j, mj) in mx.3.iter().take(len).enumerate() {
+                                pgi.extend(mj.iter().map(|mjk| (cs2 + j, mjk.1, mjk.0)));
                             }
                         }
                     }
@@ -136,15 +133,13 @@ pub fn mammalian_fixed_len_peer_groups(refdata: &RefData) -> Vec<Vec<(usize, u8,
             }
             if let Some(fs3) = fs3 {
                 if fs3 < cs3 {
-                    let x1 = start[&(chain_type.to_string(), "fwr3".to_string())];
-                    let x2 = stop[&(chain_type.to_string(), "fwr3".to_string())];
+                    let x1 = start[&(chain_type, "fwr3")];
+                    let x2 = stop[&(chain_type, "fwr3")];
                     let len = cs3 - fs3;
-                    for x in x1..x2 {
-                        if m[x].2 == len {
-                            for j in 0..len {
-                                for k in 0..m[x].3[j].len() {
-                                    pg[i].push((fs3 + j, m[x].3[j][k].1, m[x].3[j][k].0));
-                                }
+                    for mx in &m[x1..x2] {
+                        if mx.2 == len {
+                            for (j, mj) in mx.3.iter().take(len).enumerate() {
+                                pgi.extend(mj.iter().map(|mjk| (fs3 + j, mjk.1, mjk.0)));
                             }
                         }
                     }

--- a/enclone_core/src/print_tools.rs
+++ b/enclone_core/src/print_tools.rs
@@ -36,33 +36,27 @@ pub fn emit_codon_color_escape(c: &[u8], log: &mut Vec<u8>) {
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
 pub fn color_by_property(c: &[u8], log: &mut Vec<u8>) {
-    for i in 0..c.len() {
+    for &ci in c {
         let mut color = 7;
-        if c[i] == b'A'
-            || c[i] == b'G'
-            || c[i] == b'I'
-            || c[i] == b'L'
-            || c[i] == b'P'
-            || c[i] == b'V'
-        {
+        if ci == b'A' || ci == b'G' || ci == b'I' || ci == b'L' || ci == b'P' || ci == b'V' {
             color = 0;
-        } else if c[i] == b'F' || c[i] == b'W' || c[i] == b'Y' {
+        } else if ci == b'F' || ci == b'W' || ci == b'Y' {
             color = 1;
-        } else if c[i] == b'D' || c[i] == b'E' {
+        } else if ci == b'D' || ci == b'E' {
             color = 2;
-        } else if c[i] == b'R' || c[i] == b'H' || c[i] == b'K' {
+        } else if ci == b'R' || ci == b'H' || ci == b'K' {
             color = 3;
-        } else if c[i] == b'S' || c[i] == b'T' {
+        } else if ci == b'S' || ci == b'T' {
             color = 4;
-        } else if c[i] == b'C' || c[i] == b'M' {
+        } else if ci == b'C' || ci == b'M' {
             color = 5;
-        } else if c[i] == b'N' || c[i] == b'Q' {
+        } else if ci == b'N' || ci == b'Q' {
             color = 6;
         }
         if color < 7 {
             print_color(color, log);
         }
-        fwrite!(log, "{}", c[i] as char);
+        fwrite!(log, "{}", ci as char);
         if color < 7 {
             emit_end_escape(log);
         }

--- a/enclone_core/src/set_speakers.rs
+++ b/enclone_core/src/set_speakers.rs
@@ -32,21 +32,20 @@ pub fn set_speakers(ctl: &EncloneControl, parseable_fields: &mut Vec<String>, ma
         }
     }
     let mut all_lvars = lvars.clone();
-    for i in 0..LVARS_ALLOWED.len() {
-        let x = &LVARS_ALLOWED[i];
+    for x in LVARS_ALLOWED {
         if !have_gex
-            && (*x == "gex"
+            && (x == "gex"
                 || x.starts_with("gex_")
                 || x.ends_with("_g")
                 || x.ends_with("_g_μ")
-                || *x == "n_gex_cell"
-                || *x == "n_gex"
-                || *x == "n_b"
-                || *x == "clust"
-                || *x == "type"
-                || *x == "entropy"
-                || *x == "cred"
-                || *x == "cred_cell")
+                || x == "n_gex_cell"
+                || x == "n_gex"
+                || x == "n_b"
+                || x == "clust"
+                || x == "type"
+                || x == "entropy"
+                || x == "cred"
+                || x == "cred_cell")
         {
             continue;
         }
@@ -77,15 +76,15 @@ pub fn set_speakers(ctl: &EncloneControl, parseable_fields: &mut Vec<String>, ma
         ctl.parseable_opt.pchains.force_usize()
     };
     for col in 0..pchains {
-        for x in CVARS_ALLOWED.iter() {
+        for x in CVARS_ALLOWED {
             speakerc!(col, x);
         }
         if ctl.parseable_opt.pbarcode {
-            for x in CVARS_ALLOWED_PCELL.iter() {
+            for x in CVARS_ALLOWED_PCELL {
                 speakerc!(col, x);
             }
         }
-        for x in &[
+        for x in [
             "var_indices_dna",
             "var_indices_aa",
             "share_indices_dna",
@@ -99,11 +98,11 @@ pub fn set_speakers(ctl: &EncloneControl, parseable_fields: &mut Vec<String>, ma
         ] {
             speakerc!(col, x);
         }
-        for i in 0..pcols_sort.len() {
-            if pcols_sort[i].starts_with('q') && pcols_sort[i].ends_with(&format!("_{}", col + 1)) {
-                let x = pcols_sort[i].after("q").rev_before("_");
+        for pcol in pcols_sort {
+            if pcol.starts_with('q') && pcol.ends_with(&format!("_{}", col + 1)) {
+                let x = pcol.after("q").rev_before("_");
                 if x.parse::<usize>().is_ok() {
-                    parseable_fields.push(pcols_sort[i].clone());
+                    parseable_fields.push(pcol.clone());
                 }
             }
         }

--- a/enclone_core/src/slurp.rs
+++ b/enclone_core/src/slurp.rs
@@ -3,6 +3,7 @@
 // Slurp in needed data from an h5 file.
 
 use hdf5::types::FixedAscii;
+use itertools::Itertools;
 
 pub fn slurp_h5(
     h5_path: &str,
@@ -25,9 +26,7 @@ pub fn slurp_h5(
     }
     let barcodes0 = barcodes0.unwrap();
 
-    for i in 0..barcodes0.len() {
-        barcodes.push(barcodes0[i].to_string());
-    }
+    barcodes.extend(barcodes0.into_iter().map_into());
 
     // Read features from the h5 file.
 

--- a/enclone_print/src/loupe.rs
+++ b/enclone_print/src/loupe.rs
@@ -36,14 +36,13 @@ pub fn make_donor_refs(
             j += 1;
         }
         // let j = next_diff12_5(alt_refs, i as i32) as usize;
-        for k in i..j {
-            let x = &alt_refs[k];
+        for (k, x) in alt_refs[i..j].iter().enumerate() {
             let donor_id = x.0;
             let ref_id = x.1;
             let alt = x.2.to_ascii_vec();
             let alt_name = format!(
                 "{}, donor {}, alt allele {}",
-                refdata.name[ref_id].clone(),
+                refdata.name[ref_id].as_str(),
                 donor_id,
                 k - i + 1
             );
@@ -416,10 +415,7 @@ pub fn make_loupe_clonotype(
 
     // Build Clonotype.
 
-    let mut n = 0;
-    for i in 0..ecl.len() {
-        n += ecl[i].cell_barcodes.len();
-    }
+    let n = ecl.iter().map(|e| e.cell_barcodes.len()).sum::<usize>();
     Clonotype {
         chains: xchains,
         exact_clonotypes: ecl,

--- a/enclone_ranger/src/main_enclone.rs
+++ b/enclone_ranger/src/main_enclone.rs
@@ -44,20 +44,20 @@ pub fn main_enclone_ranger(args: &Vec<String>) -> Result<(), String> {
         "GAMMA_DELTA",
     ];
     let mut found = vec![false; REQUIRED_ARGS.len()];
-    for i in 1..args.len() {
-        let mut arg = args[i].clone();
+    for arg in args {
+        let mut arg = arg.as_str();
         if arg.contains('=') {
-            arg = arg.before("=").to_string();
+            arg = arg.before("=");
         }
         let mut ok = false;
-        for (j, x) in REQUIRED_ARGS.iter().enumerate() {
-            if arg == *x {
+        for (j, &x) in REQUIRED_ARGS.iter().enumerate() {
+            if arg == x {
                 ok = true;
                 found[j] = true;
             }
         }
-        for x in ALLOWED_ARGS.iter() {
-            if arg == *x {
+        for x in ALLOWED_ARGS {
+            if arg == x {
                 ok = true;
             }
         }
@@ -65,11 +65,11 @@ pub fn main_enclone_ranger(args: &Vec<String>) -> Result<(), String> {
             panic!("Illegal argument {} passed to main_enclone_ranger.", arg);
         }
     }
-    for j in 0..REQUIRED_ARGS.len() {
-        if !found[j] {
+    for (found, arg) in found.into_iter().zip(REQUIRED_ARGS.into_iter()) {
+        if found {
             panic!(
                 "Required argument {} not passed to main_enclone_ranger",
-                REQUIRED_ARGS[j]
+                arg
             );
         }
     }
@@ -86,9 +86,9 @@ pub fn main_enclone_setup_ranger(args: &Vec<String>) -> Result<EncloneSetup, Str
     let mut ctl = EncloneControl::default();
     ctl.gen_opt.cellranger = true;
     ctl.gen_opt.internal_run = false;
-    for i in 1..args.len() {
-        if args[i].starts_with("PRE=") {
-            let pre = args[i].after("PRE=").split(',').collect::<Vec<&str>>();
+    for arg in args {
+        if arg.starts_with("PRE=") {
+            let pre = arg.after("PRE=").split(',').collect::<Vec<&str>>();
             ctl.gen_opt.pre.clear();
             for x in pre.iter() {
                 ctl.gen_opt.pre.push(x.to_string());

--- a/enclone_stuff/src/disintegrate.rs
+++ b/enclone_stuff/src/disintegrate.rs
@@ -26,8 +26,8 @@ pub fn disintegrate_onesies(
             .sum();
         let mut to_info = HashMap::<usize, usize>::new();
         let mut exacts2 = Vec::<ExactClonotype>::new();
-        for i in 0..info.len() {
-            to_info.insert(info[i].clonotype_index, i);
+        for (i, inf) in info.iter().enumerate() {
+            to_info.insert(inf.clonotype_index, i);
         }
         let mut to_exact_new = Vec::<Vec<usize>>::new();
         for i in 0..exact_clonotypes.len() {
@@ -55,11 +55,12 @@ pub fn disintegrate_onesies(
             to_exact_new.push(enew);
         }
         let mut join_info2 = Vec::new();
-        for i in 0..join_info.len() {
-            let (u1, u2) = (join_info[i].0, join_info[i].1);
+        for ji in join_info.iter() {
+            let (u1, u2) = (ji.0, ji.1);
             for v1 in to_exact_new[u1].iter() {
+                join_info2.reserve(to_exact_new[u2].len());
                 for v2 in to_exact_new[u2].iter() {
-                    let mut x = join_info[i].clone();
+                    let mut x = ji.clone();
                     x.0 = *v1;
                     x.1 = *v2;
                     join_info2.push(x);
@@ -105,14 +106,14 @@ pub fn disintegrate_onesies(
         let mut reps = Vec::<i32>::new();
         eq.orbit_reps(&mut reps);
         let mut eq2 = EquivRel::new(info.len() as i32);
-        for i in 0..reps.len() {
+        for rep in reps {
             let mut o = Vec::<i32>::new();
-            eq.orbit(reps[i], &mut o);
+            eq.orbit(rep, &mut o);
             if o.len() > 1 {
-                for j in 0..o.len() - 1 {
+                for (&o1, &o2) in o.iter().zip(o.iter().skip(1)) {
                     eq2.join(
-                        to_info2[o[j] as usize][0] as i32,
-                        to_info2[o[j + 1] as usize][0] as i32,
+                        to_info2[o1 as usize][0] as i32,
+                        to_info2[o2 as usize][0] as i32,
                     );
                 }
             }

--- a/enclone_stuff/src/merge_onesies.rs
+++ b/enclone_stuff/src/merge_onesies.rs
@@ -23,10 +23,7 @@ pub fn merge_onesies(
                 to_orbit[orbits[i][j] as usize] = Some(i);
             }
         }
-        let mut ncells_total = 0;
-        for i in 0..exact_clonotypes.len() {
-            ncells_total += exact_clonotypes[i].ncells();
-        }
+        let ncells_total = exact_clonotypes.iter().map(ExactClonotype::ncells).sum();
         let mut onesies = Vec::<usize>::new();
         for i in 0..info.len() {
             if to_orbit[i].is_some()
@@ -104,12 +101,12 @@ pub fn merge_onesies(
         let mut orbits2 = Vec::<Vec<i32>>::new();
         let mut repsx = Vec::<i32>::new();
         eqo.orbit_reps(&mut repsx);
-        for i in 0..repsx.len() {
+        for r in repsx {
             let mut ox = Vec::<i32>::new();
-            eqo.orbit(repsx[i], &mut ox);
+            eqo.orbit(r, &mut ox);
             let mut o = Vec::<i32>::new();
-            for j in 0..ox.len() {
-                o.append(&mut orbits[ox[j] as usize].clone());
+            for oj in ox {
+                o.append(&mut orbits[oj as usize].clone());
             }
             orbits2.push(o);
         }

--- a/enclone_stuff/src/vars.rs
+++ b/enclone_stuff/src/vars.rs
@@ -53,17 +53,16 @@ pub fn match_vars(ctl: &mut EncloneControl, gex_info: &GexInfo) -> Result<(), St
                 if !p.is_empty() && Regex::new(p).is_ok() {
                     let mut ok = true;
                     let mut px = false;
-                    let b = p.as_bytes();
-                    for i in 0..p.len() {
-                        if !((b[i] >= b'A' && b[i] <= b'Z')
-                            || (b[i] >= b'a' && b[i] <= b'z')
-                            || (b[i] >= b'0' && b[i] <= b'9')
-                            || b".-_[]()|*".contains(&b[i]))
+                    for &b in p.as_bytes() {
+                        if !((b'A'..=b'Z').contains(&b)
+                            || (b'a'..=b'z').contains(&b)
+                            || (b'0'..=b'9').contains(&b)
+                            || b".-_[]()|*".contains(&b))
                         {
                             ok = false;
                             break;
                         }
-                        if b"[]()|*".contains(&b[i]) {
+                        if b"[]()|*".contains(&b) {
                             px = true;
                         }
                     }

--- a/enclone_vars/src/bin/export_code.rs
+++ b/enclone_vars/src/bin/export_code.rs
@@ -13,8 +13,8 @@ use std::io::Write;
 fn main() {
     PrettyTrace::new().on();
     let outs = export_code(0);
-    for i in 0..outs.len() {
-        let mut f = open_for_write_new![&outs[i].0];
-        fwrite!(f, "{}", outs[i].1);
+    for out in outs {
+        let mut f = open_for_write_new![&out.0];
+        fwrite!(f, "{}", out.1);
     }
 }

--- a/enclone_vars/src/lib.rs
+++ b/enclone_vars/src/lib.rs
@@ -3,40 +3,41 @@
 pub mod export_code;
 pub mod var;
 
+use std::fmt::Write;
 use string_utils::TextUtils;
 use vector_utils::sort_sync2;
 
 pub fn sort_vars(input: &str) -> String {
     let mut preamble = String::new();
-    let mut vars = Vec::<String>::new();
     let mut in_vars = false;
     let div = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\
-        ━━━━━━━━━━━━━━━━━━━━━";
+    ━━━━━━━━━━━━━━━━━━━━━";
     let mut groups = Vec::<String>::new();
     let mut this_group = String::new();
     for line in input.lines() {
         if !in_vars && line != div {
-            preamble += &mut format!("{}\n", line);
+            writeln!(preamble, "{}", line).unwrap();
         } else if !in_vars && line == div {
             in_vars = true;
             this_group = format!("{}\n", div);
         } else if line == div {
-            groups.push(this_group.clone());
+            groups.push(this_group);
             this_group = format!("{}\n", div);
         } else {
-            this_group += &mut format!("{}\n", line);
+            writeln!(this_group, "{}", line).unwrap();
         }
     }
-    for i in 0..groups.len() {
-        let name = groups[i].between("name:     ", "\n");
-        vars.push(name.to_string());
-    }
+    let mut vars = groups
+        .iter()
+        .map(|group| group.between("name:     ", "\n").to_string())
+        .collect::<Vec<_>>();
     sort_sync2(&mut vars, &mut groups);
+    drop(vars);
     let mut out = preamble;
-    for i in 0..groups.len() {
-        out += &mut groups[i];
+    for group in groups {
+        out += group.as_str();
     }
-    out += &mut format!("{}\n", div);
+    writeln!(out, "{}", div).unwrap();
     out
 }
 

--- a/enclone_vars/src/var.rs
+++ b/enclone_vars/src/var.rs
@@ -130,30 +130,26 @@ pub fn parse_variables(input: &str) -> Vec<Variable> {
     // Test upper-case rule.
 
     let classes = ["BC", "DATASET", "FEATURE", "INFO", "NAME", "REGA", "VARDEF"];
-    for i in 0..vars.len() {
-        let n = &vars[i].name;
-        let mut chars = Vec::<char>::new();
-        for c in n.chars() {
-            chars.push(c);
-        }
+    for var in &vars {
+        let chars = var.name.as_bytes();
         let mut j = 0;
         while j < chars.len() {
-            if chars[j] < 'A' || chars[j] > 'Z' {
+            if chars[j] < b'A' || chars[j] > b'Z' {
                 j += 1;
             } else {
                 let mut k = j + 1;
                 while k < chars.len() {
-                    if chars[k] < 'A' || chars[k] > 'Z' {
+                    if chars[k] < b'A' || chars[k] > b'Z' {
                         break;
                     }
                     k += 1;
                 }
-                let mut s = String::new();
-                for l in j..k {
-                    s.push(chars[l]);
-                }
-                if !classes.contains(&s.as_str()) {
-                    eprintln!("\nFound illegal class {} in variable name {}.\n", s, n);
+                let s: &str = &var.name[j..k];
+                if !classes.contains(&s) {
+                    eprintln!(
+                        "\nFound illegal class {} in variable name {}.\n",
+                        s, var.name
+                    );
                     std::process::exit(1);
                 }
                 j = k;


### PR DESCRIPTION
In many places, use &[u8] instead of Vec<u8> and &str instead of String,
to avoid unnecssary copying.

Fix most of the clippy::needless_range_loop warnings, except for those
in enclone_args.