### PR TITLE
Allow the option to split clonotype with large number of chains

### DIFF
--- a/enclone/src/misc2.rs
+++ b/enclone/src/misc2.rs
@@ -369,10 +369,8 @@ pub fn find_exact_subclonotypes(
         // the case where a barcode was accidentally reused.
 
         let mut to_delete = vec![false; s - r];
-        let mut bc = tig_bc[r..s]
-            .iter()
-            .enumerate()
-            .map(|(t, tig)| (tig[0].barcode.as_str(), t))
+        let mut bc = (r..s)
+            .map(|t| (tig_bc[t][0].barcode.as_str(), t))
             .collect::<Vec<_>>();
         bc.sort_unstable();
         let mut i = 0;

--- a/enclone_args/src/proc_args.rs
+++ b/enclone_args/src/proc_args.rs
@@ -162,6 +162,7 @@ pub fn proc_args(mut ctl: &mut EncloneControl, args: &[String]) -> Result<(), St
     ctl.join_alg_opt.auto_share = 15;
     ctl.join_alg_opt.comp_filt = 8;
     ctl.join_alg_opt.comp_filt_bound = 80;
+    ctl.join_alg_opt.split_max_chains = usize::MAX;
 
     ctl.join_print_opt.pfreq = 1_000_000_000;
     ctl.join_print_opt.quiet = true;
@@ -560,6 +561,7 @@ pub fn proc_args(mut ctl: &mut EncloneControl, args: &[String]) -> Result<(), St
         ("MIN_UMIS", &mut ctl.clono_filt_opt.min_umi),
         ("PFREQ", &mut ctl.join_print_opt.pfreq),
         ("SUPER_COMP_FILT", &mut ctl.join_alg_opt.super_comp_filt),
+        ("SPLIT_MAX_CHAINS", &mut ctl.join_alg_opt.split_max_chains),
     ];
 
     // Define arguments that set something to an i32.

--- a/enclone_core/src/defs.rs
+++ b/enclone_core/src/defs.rs
@@ -357,6 +357,8 @@ pub struct JoinAlgOpt {
     pub comp_filt: usize,
     pub comp_filt_bound: usize,
     pub super_comp_filt: usize,
+    /// Break up clonotypes than have `split_max_chains` chains or more
+    pub split_max_chains: usize,
 }
 
 // Clonotype filtering options.

--- a/enclone_print/src/define_mat.rs
+++ b/enclone_print/src/define_mat.rs
@@ -53,6 +53,26 @@ fn joiner(
     e
 }
 
+pub fn setup_define_mat(
+    orbit: &Vec<i32>,
+    info: &[CloneInfo],
+) -> (Vec<(Vec<usize>, usize, i32)>, Vec<usize>) {
+    let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
+    for id in orbit.iter() {
+        let x: &CloneInfo = &info[*id as usize];
+        od.push((x.origin.clone(), x.clonotype_id, *id));
+    }
+    od.sort();
+    let mut exacts = Vec::<usize>::new();
+    let mut j = 0;
+    while j < od.len() {
+        let k = next_diff12_3(&od, j as i32) as usize;
+        exacts.push(od[j].1);
+        j = k;
+    }
+    (od, exacts)
+}
+
 // This generates a cols x nexacts matrices for a given clonotype, where cols is defined by the
 // algorithm, and is the number of columns (chains) in the clonotype table.
 

--- a/enclone_print/src/define_mat.rs
+++ b/enclone_print/src/define_mat.rs
@@ -54,7 +54,7 @@ fn joiner(
 }
 
 pub fn setup_define_mat(
-    orbit: &Vec<i32>,
+    orbit: &[i32],
     info: &[CloneInfo],
 ) -> (Vec<(Vec<usize>, usize, i32)>, Vec<usize>) {
     let mut od = Vec::<(Vec<usize>, usize, i32)>::new();

--- a/enclone_ranger/src/main_enclone.rs
+++ b/enclone_ranger/src/main_enclone.rs
@@ -34,7 +34,7 @@ pub fn main_enclone_ranger(args: &[String]) -> Result<(), String> {
         "PROTO",
         "REF",
     ];
-    const ALLOWED_ARGS: [&str; 11] = [
+    const ALLOWED_ARGS: [&str; 16] = [
         "BCR",
         "META",
         "NOPRETTY",
@@ -46,6 +46,11 @@ pub fn main_enclone_ranger(args: &[String]) -> Result<(), String> {
         "NUMI",
         "NUMI_RATIO",
         "NGRAPH_FILTER",
+        "NWEAK_CHAINS",
+        "NFOURSIE_KILL",
+        "NDOUBLET",
+        "NSIG",
+        "SPLIT_MAX_CHAINS",
     ];
     let mut found = [false; REQUIRED_ARGS.len()];
     for arg in args.iter().skip(1) {

--- a/enclone_stuff/src/doublets.rs
+++ b/enclone_stuff/src/doublets.rs
@@ -8,7 +8,7 @@ use enclone_core::{
     barcode_fate::BarcodeFate,
     defs::{CloneInfo, EncloneControl, ExactClonotype},
 };
-use enclone_print::define_mat::define_mat;
+use enclone_print::define_mat::{define_mat, setup_define_mat};
 use enclone_proto::types::DonorReferenceItem;
 use itertools::Itertools;
 use qd::Double;
@@ -47,19 +47,7 @@ pub fn delete_doublets(
         results.par_iter_mut().for_each(|res| {
             let i = res.0;
             let o = orbits[i].clone();
-            let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
-            for id in o.iter() {
-                let x: &CloneInfo = &info[*id as usize];
-                od.push((x.origin.clone(), x.clonotype_id, *id));
-            }
-            od.sort();
-            let mut exacts = Vec::<usize>::new();
-            let mut j = 0;
-            while j < od.len() {
-                let k = next_diff12_3(&od, j as i32) as usize;
-                exacts.push(od[j].1);
-                j = k;
-            }
+            let (od, exacts) = setup_define_mat(&o, info);
             let mat = define_mat(
                 is_bcr,
                 to_bc,

--- a/enclone_stuff/src/doublets.rs
+++ b/enclone_stuff/src/doublets.rs
@@ -16,7 +16,7 @@ use rayon::prelude::*;
 use std::collections::HashMap;
 use std::time::Instant;
 use vdj_ann::refx::RefData;
-use vector_utils::{bin_member, erase_if, next_diff, next_diff12_3, next_diff1_2, sort_sync2};
+use vector_utils::{bin_member, erase_if, next_diff, next_diff1_2, sort_sync2};
 
 pub fn delete_doublets(
     orbits: &mut Vec<Vec<i32>>,
@@ -47,7 +47,7 @@ pub fn delete_doublets(
         results.par_iter_mut().for_each(|res| {
             let i = res.0;
             let o = orbits[i].clone();
-            let (od, exacts) = setup_define_mat(&o, info);
+            let (od, mut exacts) = setup_define_mat(&o, info);
             let mat = define_mat(
                 is_bcr,
                 to_bc,

--- a/enclone_stuff/src/some_filters.rs
+++ b/enclone_stuff/src/some_filters.rs
@@ -16,7 +16,7 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 use vdj_ann::refx::RefData;
-use vector_utils::{erase_if, next_diff12_3, next_diff1_2, unique_sort};
+use vector_utils::{erase_if, next_diff1_2, unique_sort};
 
 pub fn some_filters(
     orbits: &mut Vec<Vec<i32>>,

--- a/enclone_stuff/src/some_filters.rs
+++ b/enclone_stuff/src/some_filters.rs
@@ -6,7 +6,7 @@ use crate::split_orbits::split_orbits;
 use crate::weak_chains::weak_chains;
 use enclone_core::barcode_fate::BarcodeFate;
 use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
-use enclone_print::define_mat::define_mat;
+use enclone_print::define_mat::{define_mat, setup_define_mat};
 use enclone_print::print_utils3::define_column_info;
 use enclone_proto::types::DonorReferenceItem;
 use equiv::EquivRel;
@@ -64,19 +64,7 @@ pub fn some_filters(
     results.par_iter_mut().for_each(|res| {
         let i = res.0;
         let o = orbits[i].clone();
-        let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
-        for id in o.iter() {
-            let x: &CloneInfo = &info[*id as usize];
-            od.push((x.origin.clone(), x.clonotype_id, *id));
-        }
-        od.sort();
-        let mut exacts = Vec::<usize>::new();
-        let mut j = 0;
-        while j < od.len() {
-            let k = next_diff12_3(&od, j as i32) as usize;
-            exacts.push(od[j].1);
-            j = k;
-        }
+        let (od, exacts) = setup_define_mat(&o, info);
         let mat = define_mat(
             is_bcr,
             to_bc,
@@ -269,19 +257,7 @@ pub fn some_filters(
     results.par_iter_mut().for_each(|res| {
         let i = res.0;
         let o = orbits[i].clone();
-        let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
-        for id in o.iter() {
-            let x: &CloneInfo = &info[*id as usize];
-            od.push((x.origin.clone(), x.clonotype_id, *id));
-        }
-        od.sort();
-        let mut exacts = Vec::<usize>::new();
-        let mut j = 0;
-        while j < od.len() {
-            let k = next_diff12_3(&od, j as i32) as usize;
-            exacts.push(od[j].1);
-            j = k;
-        }
+        let (od, exacts) = setup_define_mat(&o, info);
         let mat = define_mat(
             is_bcr,
             to_bc,
@@ -472,5 +448,6 @@ pub fn some_filters(
         refdata,
         dref,
     );
+    // *orbits = orbits.iter().flatten().map(|x| vec![*x]).collect();
     ctl.perf_stats(&tsplit, "splitting orbits 3");
 }

--- a/enclone_stuff/src/split_orbits.rs
+++ b/enclone_stuff/src/split_orbits.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
 use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
-use enclone_print::define_mat::define_mat;
+use enclone_print::define_mat::{define_mat, setup_define_mat};
 use enclone_proto::types::DonorReferenceItem;
 use equiv::EquivRel;
 use qd::Double;
 use std::collections::HashMap;
 use vdj_ann::refx::RefData;
-use vector_utils::{bin_position, next_diff12_3, unique_sort, VecUtils};
+use vector_utils::{bin_position, unique_sort, VecUtils};
 
 // Check for disjoint orbits.
 
@@ -25,19 +25,7 @@ pub fn split_orbits(
 ) {
     let mut orbits2 = Vec::<Vec<i32>>::new();
     for o in orbits.iter() {
-        let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
-        for id in o.iter() {
-            let x: &CloneInfo = &info[*id as usize];
-            od.push((x.origin.clone(), x.clonotype_id, *id));
-        }
-        od.sort();
-        let mut exacts = Vec::<usize>::new();
-        let mut j = 0;
-        while j < od.len() {
-            let k = next_diff12_3(&od, j as i32) as usize;
-            exacts.push(od[j].1);
-            j = k;
-        }
+        let (od, exacts) = setup_define_mat(o, info);
         let mat = define_mat(
             is_bcr,
             to_bc,

--- a/enclone_stuff/src/start.rs
+++ b/enclone_stuff/src/start.rs
@@ -29,7 +29,6 @@ use equiv::EquivRel;
 use io_utils::{fwriteln, open_for_read};
 use itertools::Itertools;
 use qd::dd;
-use std::collections::HashSet;
 use std::{
     collections::HashMap,
     env,

--- a/enclone_stuff/src/start.rs
+++ b/enclone_stuff/src/start.rs
@@ -542,27 +542,9 @@ pub fn main_enclone_start(setup: EncloneSetup) -> Result<EncloneIntermediates, S
     filter_by_fcell(ctl, &mut orbits, info, &mut exact_clonotypes, gex_info)?;
     ctl.perf_stats(&tumi, "umi filtering and such");
 
-    // Run some filters.
-
-    some_filters(
-        &mut orbits,
-        is_bcr,
-        &to_bc,
-        &sr,
-        ctl,
-        &exact_clonotypes,
-        info,
-        &raw_joins,
-        &eq,
-        &disintegrated,
-        &mut fate,
-        refdata,
-        &drefs,
-    );
-
     // Break up clonotypes containing a large number of chains. These are
     // very likely to be false merges
-    let orbits: Vec<Vec<i32>> = orbits
+    let mut orbits: Vec<Vec<i32>> = orbits
         .into_iter()
         .flat_map(|orbit| {
             let (od, exacts) = setup_define_mat(&orbit, info);
@@ -630,6 +612,24 @@ pub fn main_enclone_start(setup: EncloneSetup) -> Result<EncloneIntermediates, S
             }
         })
         .collect();
+
+    // Run some filters.
+
+    some_filters(
+        &mut orbits,
+        is_bcr,
+        &to_bc,
+        &sr,
+        ctl,
+        &exact_clonotypes,
+        info,
+        &raw_joins,
+        &eq,
+        &disintegrated,
+        &mut fate,
+        refdata,
+        &drefs,
+    );
 
     // Pre evaluate (PRE_EVAL).
 

--- a/enclone_stuff/src/weak_chains.rs
+++ b/enclone_stuff/src/weak_chains.rs
@@ -13,7 +13,7 @@ use qd::Double;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use vdj_ann::refx::RefData;
-use vector_utils::{erase_if, next_diff12_3};
+use vector_utils::erase_if;
 
 pub fn weak_chains(
     orbits: &mut Vec<Vec<i32>>,

--- a/enclone_stuff/src/weak_chains.rs
+++ b/enclone_stuff/src/weak_chains.rs
@@ -7,7 +7,7 @@ use enclone_core::{
     barcode_fate::BarcodeFate,
     defs::{CloneInfo, EncloneControl, ExactClonotype},
 };
-use enclone_print::define_mat::define_mat;
+use enclone_print::define_mat::{define_mat, setup_define_mat};
 use enclone_proto::types::DonorReferenceItem;
 use qd::Double;
 use rayon::prelude::*;
@@ -37,19 +37,7 @@ pub fn weak_chains(
     results.par_iter_mut().for_each(|res| {
         let i = res.0;
         let o = orbits[i].clone();
-        let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
-        for id in o.iter() {
-            let x: &CloneInfo = &info[*id as usize];
-            od.push((x.origin.clone(), x.clonotype_id, *id));
-        }
-        od.sort();
-        let mut exacts = Vec::<usize>::new();
-        let mut j = 0;
-        while j < od.len() {
-            let k = next_diff12_3(&od, j as i32) as usize;
-            exacts.push(od[j].1);
-            j = k;
-        }
+        let (od, exacts) = setup_define_mat(&o, info);
         let mat = define_mat(
             is_bcr,
             to_bc,


### PR DESCRIPTION
Adds the argument `SPLIT_MAX_CHAINS=n`, which will split each clonotype with `n` chains or more such that each of its exact subclonotypes become a different clonotype.

An example of a clonotype with large number of chains when the filters are tuned off

```
   ┌────────┬────────────────────────┬──────────────────┬───────┐
   │chains  │  clonotypes with this  │  cells in these  │      %│
   │        │      number of chains  │      clonotypes  │       │
   ├────────┼────────────────────────┼──────────────────┼───────┤
   │1       │                    88  │            1932  │   57.4│
   │2       │                   102  │             388  │   11.5│
   │3       │                     6  │               7  │    0.2│
   │4       │                     1  │               1  │    0.0│
   │48      │                     1  │            1040  │   30.9│
   │total   │                   198  │            3368  │  100.0│
   └────────┴────────────────────────┴──────────────────┴───────┘
```

Adding `SPLIT_MAX_CHAINS=4`
```
   ┌────────┬────────────────────────┬──────────────────┬───────┐
   │chains  │  clonotypes with this  │  cells in these  │      %│
   │        │      number of chains  │      clonotypes  │       │
   ├────────┼────────────────────────┼──────────────────┼───────┤
   │1       │                   109  │            2090  │   62.1│
   │2       │                   152  │            1194  │   35.5│
   │3       │                    68  │              83  │    2.5│
   │4       │                     1  │               1  │    0.0│
   │total   │                   330  │            3368  │  100.0│
   └────────┴────────────────────────┴──────────────────┴───────┘
```