### PR TITLE
deny clippy::type_complexity

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -60,7 +60,6 @@ rustflags = [
   # --- lint allow ---
   "-A", "clippy::comparison_chain",
   # TODO: burn down these allow exceptions and then deny them
-  "-W", "clippy::type_complexity",
   "-A", "clippy::too_many_arguments",
   "-A", "clippy::needless_range_loop",
 ]

--- a/.cargo/config
+++ b/.cargo/config
@@ -60,7 +60,7 @@ rustflags = [
   # --- lint allow ---
   "-A", "clippy::comparison_chain",
   # TODO: burn down these allow exceptions and then deny them
-  "-A", "clippy::type_complexity",
+  "-W", "clippy::type_complexity",
   "-A", "clippy::too_many_arguments",
   "-A", "clippy::needless_range_loop",
 ]

--- a/enclone/src/join.rs
+++ b/enclone/src/join.rs
@@ -92,10 +92,10 @@ pub fn join_exacts(
     }
 
     let joinf = |r: &mut JoinResult| {
-        let (i, j) = (r.f0, r.f1);
-        let joins = &mut r.f2;
-        let errors = &mut r.f3;
-        let logplus = &mut r.f4;
+        let (i, j) = (r.i, r.j);
+        let joins = &mut r.joins;
+        let errors = &mut r.errors;
+        let logplus = &mut r.join_info;
         let mut pot = Vec::<PotentialJoin<'_>>::new();
 
         // Main join logic.  If you change par_iter_mut to iter_mut above, and run happening,
@@ -208,7 +208,7 @@ pub fn join_exacts(
 
             // Save join and tally stats.
 
-            r.f5.push((k1, k2));
+            r.join_list.push((k1, k2));
             *joins += 1;
             if err {
                 *errors += 1;
@@ -573,10 +573,10 @@ pub fn join_exacts(
             }
             */
             logplus.push(JoinInfo {
-                j0: info[k1].clonotype_index,
-                j1: info[k2].clonotype_index,
-                j2: err,
-                j3: log,
+                index1: info[k1].clonotype_index,
+                index2: info[k2].clonotype_index,
+                err,
+                log,
             });
         }
     };
@@ -584,7 +584,7 @@ pub fn join_exacts(
     results.par_iter_mut().for_each(joinf);
 
     for r in &results {
-        for &j in &r.f5 {
+        for &j in &r.join_list {
             raw_joins.push((j.0 as i32, j.1 as i32));
         }
     }

--- a/enclone/src/join2.rs
+++ b/enclone/src/join2.rs
@@ -12,23 +12,23 @@ use stats_utils::percent_ratio;
 use vector_utils::next_diff1_2;
 
 pub struct JoinResult {
-    pub f0: usize,               //i
-    pub f1: usize,               //j
-    pub f2: usize,               //joins
-    pub f3: usize,               //errors
-    pub f4: Vec<JoinInfo>,       //join_info
-    pub f5: Vec<(usize, usize)>, //join_list
+    pub i: usize,
+    pub j: usize,
+    pub joins: usize,
+    pub errors: usize,
+    pub join_info: Vec<JoinInfo>,
+    pub join_list: Vec<(usize, usize)>,
 }
 
 impl JoinResult {
     pub fn new(i: usize, j: usize) -> Self {
         Self {
-            f0: i,
-            f1: j,
-            f2: 0,
-            f3: 0,
-            f4: Default::default(),
-            f5: Default::default(),
+            i,
+            j,
+            joins: 0,
+            errors: 0,
+            join_info: Default::default(),
+            join_list: Default::default(),
         }
     }
 }
@@ -45,10 +45,10 @@ pub fn finish_join(
     let mut eq: EquivRel = EquivRel::new(info.len() as i32);
 
     for r in results {
-        joins += r.f2;
-        errors += r.f3;
-        join_info.extend(r.f4.into_iter());
-        for j in &r.f5 {
+        joins += r.joins;
+        errors += r.errors;
+        join_info.extend(r.join_info.into_iter());
+        for j in &r.join_list {
             eq.join(j.0 as i32, j.1 as i32);
         }
     }

--- a/enclone/src/join2.rs
+++ b/enclone/src/join2.rs
@@ -2,39 +2,54 @@
 
 // This file provides the tail end code for join.rs, plus a small function used there.
 
-use enclone_core::defs::{CloneInfo, EncloneControl};
+use enclone_core::{
+    defs::{CloneInfo, EncloneControl},
+    enclone_structs::JoinInfo,
+};
 use equiv::EquivRel;
 use stats_utils::percent_ratio;
 
 use vector_utils::next_diff1_2;
 
-// ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+pub struct JoinResult {
+    pub f0: usize,               //i
+    pub f1: usize,               //j
+    pub f2: usize,               //joins
+    pub f3: usize,               //errors
+    pub f4: Vec<JoinInfo>,       //join_info
+    pub f5: Vec<(usize, usize)>, //join_list
+}
+
+impl JoinResult {
+    pub fn new(i: usize, j: usize) -> Self {
+        Self {
+            f0: i,
+            f1: j,
+            f2: 0,
+            f3: 0,
+            f4: Default::default(),
+            f5: Default::default(),
+        }
+    }
+}
 
 pub fn finish_join(
     ctl: &EncloneControl,
     info: &[CloneInfo],
-    results: &[(
-        usize,
-        usize,
-        usize,
-        usize,
-        Vec<(usize, usize, bool, Vec<u8>)>,
-        Vec<(usize, usize)>,
-    )],
-    join_info: &mut Vec<(usize, usize, bool, Vec<u8>)>,
+    results: Vec<JoinResult>,
+    join_info: &mut Vec<JoinInfo>,
 ) -> EquivRel {
     // Tally results.
-
+    // Make equivalence relation.
     let (mut joins, mut errors) = (0, 0);
+    let mut eq: EquivRel = EquivRel::new(info.len() as i32);
+
     for r in results {
-        joins += r.2;
-        errors += r.3;
-        for i in &r.4 {
-            let u1 = i.0;
-            let u2 = i.1;
-            let err = i.2;
-            let log = i.3.clone();
-            join_info.push((u1, u2, err, log));
+        joins += r.f2;
+        errors += r.f3;
+        join_info.extend(r.f4.into_iter());
+        for j in &r.f5 {
+            eq.join(j.0 as i32, j.1 as i32);
         }
     }
     if !ctl.silent {
@@ -43,14 +58,12 @@ pub fn finish_join(
             println!("{errors} errors");
         }
     }
-
-    // Make equivalence relation.
-
-    let mut eq: EquivRel = EquivRel::new(info.len() as i32);
-    for r in results {
-        for j in &r.5 {
-            eq.join(j.0 as i32, j.1 as i32);
-        }
+    // Report whitelist contamination.
+    // WARNING: THIS ONLY WORKS IF YOU RUN WITH CLONES=1 AND NO OTHER FILTERS.
+    // TODO: we should actually make an assertion that this is true.
+    if ctl.clono_filt_opt_def.whitef || ctl.clono_print_opt.cvars.iter().any(|var| var == "white") {
+        let bad_rate = percent_ratio(joins, errors);
+        println!("whitelist contamination rate = {bad_rate:.2}%");
     }
 
     // Join orbits that cross subclones of a clone.  This arose because we split up multi-chain
@@ -68,26 +81,6 @@ pub fn finish_join(
             eq.join(ox[k].1, ox[k + 1].1);
         }
         i = j;
-    }
-
-    // Tally whitelist contamination.
-    // WARNING: THIS ONLY WORKS IF YOU RUN WITH CLONES=1 AND NO OTHER FILTERS.
-
-    let mut white = ctl.clono_filt_opt_def.whitef;
-    for j in 0..ctl.clono_print_opt.cvars.len() {
-        if ctl.clono_print_opt.cvars[j] == "white" {
-            white = true;
-        }
-    }
-    if white {
-        let mut bads = 0;
-        let mut denom = 0;
-        for r in results {
-            bads += r.2;
-            denom += r.3;
-        }
-        let bad_rate = percent_ratio(bads, denom);
-        println!("whitelist contamination rate = {bad_rate:.2}%");
     }
 
     eq

--- a/enclone_core/src/enclone_structs.rs
+++ b/enclone_core/src/enclone_structs.rs
@@ -67,8 +67,8 @@ pub struct EncloneExacts {
 
 #[derive(Clone)]
 pub struct JoinInfo {
-    pub j0: usize,   //index1
-    pub j1: usize,   //index2
-    pub j2: bool,    //err?
-    pub j3: Vec<u8>, //log
+    pub index1: usize,
+    pub index2: usize,
+    pub err: bool,
+    pub log: Vec<u8>,
 }

--- a/enclone_core/src/enclone_structs.rs
+++ b/enclone_core/src/enclone_structs.rs
@@ -57,10 +57,18 @@ pub struct EncloneExacts {
     pub info: Vec<CloneInfo>,
     pub orbits: Vec<Vec<i32>>,
     pub vdj_cells: Vec<Vec<String>>,
-    pub join_info: Vec<(usize, usize, bool, Vec<u8>)>,
+    pub join_info: Vec<JoinInfo>,
     pub drefs: Vec<DonorReferenceItem>,
     pub sr: Vec<Vec<Double>>,
     pub fate: Vec<HashMap<String, BarcodeFate>>, // GETS MODIFIED SUBSEQUENTLY
     pub is_bcr: bool,
     pub allele_data: AlleleData,
+}
+
+#[derive(Clone)]
+pub struct JoinInfo {
+    pub j0: usize,   //index1
+    pub j1: usize,   //index2
+    pub j2: bool,    //err?
+    pub j3: Vec<u8>, //log
 }

--- a/enclone_core/src/mammalian_fixed_len.rs
+++ b/enclone_core/src/mammalian_fixed_len.rs
@@ -9,6 +9,7 @@ use vdj_ann::vdj_features::{cdr1_start, cdr2_start, cdr3_start, fr1_start, fr2_s
 
 // {chain, feature, len, {{(count, amino_acid)}}}
 
+#[allow(clippy::type_complexity)]
 pub fn mammalian_fixed_len() -> Vec<(&'static str, &'static str, usize, Vec<Vec<(u32, u8)>>)> {
     const X: &str = include_str!("mammalian_fixed_len.table");
     X.lines()

--- a/enclone_print/src/define_mat.rs
+++ b/enclone_print/src/define_mat.rs
@@ -53,11 +53,11 @@ fn joiner(
     e
 }
 
-pub fn setup_define_mat(
-    orbit: &[i32],
-    info: &[CloneInfo],
-) -> (Vec<(Vec<usize>, usize, i32)>, Vec<usize>) {
-    let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
+// TOOD: refactor this into a struct
+pub type Od = (Vec<usize>, usize, i32);
+
+pub fn setup_define_mat(orbit: &[i32], info: &[CloneInfo]) -> (Vec<Od>, Vec<usize>) {
+    let mut od = Vec::<Od>::new();
     for id in orbit {
         let x: &CloneInfo = &info[*id as usize];
         od.push((x.origin.clone(), x.clonotype_id, *id));
@@ -83,7 +83,7 @@ pub fn define_mat(
     ctl: &EncloneControl,
     exact_clonotypes: &[ExactClonotype],
     exacts: &[usize],
-    od: &[(Vec<usize>, usize, i32)],
+    od: &[Od],
     info: &[CloneInfo],
     raw_joins: &[Vec<usize>],
     refdata: &RefData,

--- a/enclone_print/src/finish_table.rs
+++ b/enclone_print/src/finish_table.rs
@@ -12,6 +12,11 @@ use string_utils::TextUtils;
 use vdj_ann::refx::RefData;
 use vector_utils::bin_member;
 
+pub struct Sr {
+    pub row: Vec<String>,
+    pub subrows: Vec<Vec<String>>,
+}
+
 pub fn finish_table(
     n: usize,
     ctl: &EncloneControl,
@@ -28,7 +33,7 @@ pub fn finish_table(
     mlog: &mut Vec<u8>,
     logz: &mut String,
     stats: &[(String, Vec<String>)],
-    sr: &mut [(Vec<String>, Vec<Vec<String>>, Vec<Vec<u8>>, usize)],
+    sr: Vec<Sr>,
     extra_args: &[String],
     pcols_sort: &[String],
     out_data: &mut Vec<HashMap<String, String>>,
@@ -144,10 +149,10 @@ pub fn finish_table(
 
     // Finish building table content.
 
-    for (j, srj) in sr.iter_mut().enumerate() {
-        srj.0[0] = format!("{}", j + 1); // row number (#)
-        rows.push(srj.0.clone());
-        rows.extend(srj.1.clone());
+    for (j, mut srj) in sr.into_iter().enumerate() {
+        srj.row[0] = format!("{}", j + 1); // row number (#)
+        rows.push(srj.row);
+        rows.extend(srj.subrows);
     }
 
     // Add sum and mean rows.

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -5,7 +5,7 @@
 //
 // Problem: stack traces from this file consistently do not go back to the main program.
 
-use crate::define_mat::define_mat;
+use crate::define_mat::{define_mat, Od};
 use crate::filter::survives_filter;
 use crate::finish_table::{finish_table, Sr};
 use crate::gene_scan::gene_scan_test;
@@ -225,7 +225,7 @@ pub fn print_clonotypes(
     results.par_iter_mut().for_each(|res| {
         let i = res.0;
         let o = &orbits[i];
-        let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
+        let mut od = Vec::<Od>::new();
         for id in o {
             let x: &CloneInfo = &info[*id as usize];
             od.push((x.origin.clone(), x.clonotype_id, *id));

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -7,7 +7,7 @@
 
 use crate::define_mat::define_mat;
 use crate::filter::survives_filter;
-use crate::finish_table::finish_table;
+use crate::finish_table::{finish_table, Sr};
 use crate::gene_scan::gene_scan_test;
 use crate::loupe::{loupe_out, make_loupe_clonotype};
 use crate::print_utils1::{compute_field_types, extra_args, start_gen};
@@ -524,7 +524,7 @@ pub fn print_clonotypes(
 
                 // Now build table content.
 
-                let mut sr = Vec::<(Vec<String>, Vec<Vec<String>>, Vec<Vec<u8>>, usize)>::new();
+                let mut sr = Vec::<Sr>::new();
                 let mut groups = HashMap::<usize, Vec<usize>>::new();
                 for lvar in &lvars {
                     if let Some(Ok(d)) = lvar.strip_prefix('g').map(str::parse::<usize>) {
@@ -712,7 +712,6 @@ pub fn print_clonotypes(
                             exact_clonotypes,
                             &mut row,
                             &mut subrows,
-                            &varmat,
                             have_gex,
                             gex_info,
                             &rsi,
@@ -883,7 +882,7 @@ pub fn print_clonotypes(
                     &mut mlog,
                     &mut logz,
                     &stats,
-                    &mut sr,
+                    sr,
                     &extra_args,
                     pcols_sort,
                     &mut out_data,

--- a/enclone_print/src/print_utils4.rs
+++ b/enclone_print/src/print_utils4.rs
@@ -13,6 +13,8 @@ use string_utils::TextUtils;
 use vdj_ann::refx::RefData;
 use vector_utils::{bin_member, bin_position, bin_position1_2, unique_sort};
 
+use crate::finish_table::Sr;
+
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
 pub fn get_gex_matrix_entry(
@@ -495,11 +497,10 @@ pub fn compute_bu(
     exact_clonotypes: &[ExactClonotype],
     row: &mut [String],
     subrows: &mut Vec<Vec<String>>,
-    varmat: &[Vec<Vec<u8>>],
     have_gex: bool,
     gex_info: &GexInfo,
     rsi: &ColInfo,
-    sr: &mut Vec<(Vec<String>, Vec<Vec<String>>, Vec<Vec<u8>>, usize)>,
+    sr: &mut Vec<Sr>,
     fate: &[HashMap<String, BarcodeFate>],
     nd_fields: &[String],
     alt_bcs: &[String],
@@ -870,5 +871,8 @@ pub fn compute_bu(
             subrows.push(row);
         }
     }
-    sr.push((row.to_vec(), subrows.clone(), varmat[u].clone(), u));
+    sr.push(Sr {
+        row: row.to_vec(),
+        subrows: subrows.clone(),
+    });
 }

--- a/enclone_stuff/src/disintegrate.rs
+++ b/enclone_stuff/src/disintegrate.rs
@@ -58,13 +58,13 @@ pub fn disintegrate_onesies(
         }
         let mut join_info2 = Vec::new();
         for ji in join_info.iter() {
-            let (u1, u2) = (ji.j0, ji.j1);
+            let (u1, u2) = (ji.index1, ji.index2);
             for v1 in &to_exact_new[u1] {
                 join_info2.reserve(to_exact_new[u2].len());
                 for v2 in &to_exact_new[u2] {
                     let mut x = ji.clone();
-                    x.j0 = *v1;
-                    x.j1 = *v2;
+                    x.index1 = *v1;
+                    x.index2 = *v2;
                     join_info2.push(x);
                 }
             }

--- a/enclone_stuff/src/disintegrate.rs
+++ b/enclone_stuff/src/disintegrate.rs
@@ -3,7 +3,10 @@
 // If NWEAK_ONESIES is not specified, disintegrate certain onesie clonotypes into single cell
 // clonotypes.  This requires editing of exact_clonotypes, info, eq, join_info and raw_joins.
 
-use enclone_core::defs::{CloneInfo, EncloneControl, ExactClonotype};
+use enclone_core::{
+    defs::{CloneInfo, EncloneControl, ExactClonotype},
+    enclone_structs::JoinInfo,
+};
 use equiv::EquivRel;
 use std::collections::HashMap;
 
@@ -15,7 +18,7 @@ pub fn disintegrate_onesies(
     eq: &mut EquivRel,
     exact_clonotypes: &mut Vec<ExactClonotype>,
     info: &mut Vec<CloneInfo>,
-    join_info: &mut Vec<(usize, usize, bool, Vec<u8>)>,
+    join_info: &mut Vec<JoinInfo>,
     raw_joins: &mut Vec<(i32, i32)>,
 ) {
     if ctl.clono_filt_opt_def.weak_onesies {
@@ -55,13 +58,13 @@ pub fn disintegrate_onesies(
         }
         let mut join_info2 = Vec::new();
         for ji in join_info.iter() {
-            let (u1, u2) = (ji.0, ji.1);
+            let (u1, u2) = (ji.j0, ji.j1);
             for v1 in &to_exact_new[u1] {
                 join_info2.reserve(to_exact_new[u2].len());
                 for v2 in &to_exact_new[u2] {
                     let mut x = ji.clone();
-                    x.0 = *v1;
-                    x.1 = *v2;
+                    x.j0 = *v1;
+                    x.j1 = *v2;
                     join_info2.push(x);
                 }
             }

--- a/enclone_stuff/src/start.rs
+++ b/enclone_stuff/src/start.rs
@@ -23,7 +23,7 @@ use enclone_core::barcode_fate::BarcodeFate;
 use enclone_core::defs::{AlleleData, CloneInfo};
 use enclone_core::enclone_structs::{EncloneExacts, EncloneIntermediates, EncloneSetup, JoinInfo};
 use enclone_core::hcomp::heavy_complexity;
-use enclone_print::define_mat::{define_mat, setup_define_mat};
+use enclone_print::define_mat::{define_mat, setup_define_mat, Od};
 use enclone_print::loupe::make_donor_refs;
 use equiv::EquivRel;
 use io_utils::{fwriteln, open_for_read};
@@ -623,7 +623,7 @@ pub fn main_enclone_start(setup: EncloneSetup) -> Result<EncloneIntermediates, S
             results.par_iter_mut().for_each(|res| {
                 let i = res.0;
                 let o = &orbits[i];
-                let mut od = Vec::<(Vec<usize>, usize, i32)>::new();
+                let mut od = Vec::<Od>::new();
                 for id in o {
                     let x: &CloneInfo = &info[*id as usize];
                     od.push((x.origin.clone(), x.clonotype_id, *id));

--- a/enclone_stuff/src/start.rs
+++ b/enclone_stuff/src/start.rs
@@ -21,7 +21,7 @@ use enclone::misc3::sort_tig_bc;
 use enclone_args::read_json::{parse_json_annotations_files, Annotations};
 use enclone_core::barcode_fate::BarcodeFate;
 use enclone_core::defs::{AlleleData, CloneInfo};
-use enclone_core::enclone_structs::{EncloneExacts, EncloneIntermediates, EncloneSetup};
+use enclone_core::enclone_structs::{EncloneExacts, EncloneIntermediates, EncloneSetup, JoinInfo};
 use enclone_core::hcomp::heavy_complexity;
 use enclone_print::define_mat::{define_mat, setup_define_mat};
 use enclone_print::loupe::make_donor_refs;
@@ -360,7 +360,7 @@ pub fn main_enclone_start(setup: EncloneSetup) -> Result<EncloneIntermediates, S
     // Form equivalence relation on exact subclonotypes.  We also keep the raw joins, consisting
     // of pairs of info indices, that were originally joined.
 
-    let mut join_info = Vec::<(usize, usize, bool, Vec<u8>)>::new();
+    let mut join_info = Vec::<JoinInfo>::new();
     let mut raw_joins = Vec::<(i32, i32)>::new();
     let mut eq: EquivRel = join_exacts(
         is_bcr,


### PR DESCRIPTION
Removes the allow exception for `clippy::type_complexity` and fixes all errors.  I was mostly able to replace anonymous tuples with structs, but one section relied on some existing tuple-specific logic so I created a type alias and moved on.

Stacked on another feature branch, will rebase once underlying branch merges.