### PR TITLE
deny clippy::needless_range_loop

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -61,7 +61,6 @@ rustflags = [
   "-A", "clippy::comparison_chain",
   # TODO: burn down these allow exceptions and then deny them
   "-A", "clippy::too_many_arguments",
-  "-W", "clippy::needless_range_loop",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/.cargo/config
+++ b/.cargo/config
@@ -61,7 +61,7 @@ rustflags = [
   "-A", "clippy::comparison_chain",
   # TODO: burn down these allow exceptions and then deny them
   "-A", "clippy::too_many_arguments",
-  "-A", "clippy::needless_range_loop",
+  "-W", "clippy::needless_range_loop",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/dna/src/lib.rs
+++ b/dna/src/lib.rs
@@ -91,12 +91,7 @@ pub fn tm_nearest_neighbor_full(s: &str, s_mol: f64, na_mol: f64, locked: &[bool
     for c in s.chars() {
         sx.push(c);
     }
-    let mut gc = 0;
-    for i in 0..sx.len() {
-        if sx[i] == 'G' || sx[i] == 'C' {
-            gc += 1;
-        }
-    }
+    let gc = sx.iter().filter(|c| **c == 'G' || **c == 'C').count();
     let gc_fract = gc as f64 / sx.len() as f64;
     let ln_na_mol = na_mol.ln();
 
@@ -431,12 +426,12 @@ pub fn thermodynamic_sums_dna(
         sx.push(c);
     }
     let mut b = Vec::<usize>::new();
-    for i in 0..sx.len() {
-        if sx[i] == 'A' {
+    for sx_i in &sx {
+        if *sx_i == 'A' {
             b.push(0);
-        } else if sx[i] == 'C' {
+        } else if *sx_i == 'C' {
             b.push(1);
-        } else if sx[i] == 'G' {
+        } else if *sx_i == 'G' {
             b.push(2);
         } else {
             b.push(3);
@@ -451,8 +446,8 @@ pub fn thermodynamic_sums_dna(
     // Handle locked bases.
 
     let mut have_lock = false;
-    for i in 0..locked.len() {
-        if locked[i] {
+    for locked_i in locked {
+        if *locked_i {
             have_lock = true;
         }
     }

--- a/fasta_tools/src/lib.rs
+++ b/fasta_tools/src/lib.rs
@@ -131,9 +131,7 @@ pub fn read_fasta_contents_into_vec_dna_string_plus_headers(
 ) {
     let mut last: String = String::new();
     let mut first = true;
-    let lines = f.split('\n').collect::<Vec<&str>>();
-    for i in 0..lines.len() {
-        let s = &lines[i];
+    for s in f.split('\n') {
         if first {
             if !s.starts_with('>') {
                 panic!("fasta format failure reading {}", f);

--- a/graph_simple/src/lib.rs
+++ b/graph_simple/src/lib.rs
@@ -174,8 +174,8 @@ where
     fn get_predecessors(&self, v: &[i32], x: &mut Vec<u32>) {
         let mut check: Vec<u32> = Vec::new();
         let mut tov: HashSet<u32> = HashSet::new();
-        for j in 0..v.len() {
-            let s: u32 = v[j] as u32;
+        for v_i in v {
+            let s: u32 = *v_i as u32;
             check.push(s);
             tov.insert(s);
         }
@@ -205,8 +205,8 @@ where
     fn get_successors(&self, v: &[i32], x: &mut Vec<u32>) {
         let mut check: Vec<u32> = Vec::new();
         let mut fromv: HashSet<u32> = HashSet::new();
-        for j in 0..v.len() {
-            let s: u32 = v[j] as u32;
+        for v_i in v {
+            let s: u32 = *v_i as u32;
             check.push(s);
             fromv.insert(s);
         }
@@ -275,23 +275,23 @@ where
 
     fn components_e(&self, comp: &mut Vec<Vec<u32>>) {
         self.components(comp);
-        for j in 0..comp.len() {
+        for comp_i in comp {
             let mut c = Vec::<u32>::new();
-            for i in 0..comp[j].len() {
-                let v = comp[j][i];
+            for comp_i_j in comp_i.iter() {
+                let v = *comp_i_j;
                 let n = self.n_from(v as usize);
                 for l in 0..n {
                     c.push(self.e_from(v as usize, l) as u32);
                 }
             }
-            comp[j] = c;
+            *comp_i = c;
         }
     }
 
     fn components_e_pos_sorted(&self, comp: &mut Vec<Vec<u32>>) {
         self.components_e(comp);
-        for u in 0..comp.len() {
-            comp[u].sort_by(|a, b| {
+        for comp_i in comp {
+            comp_i.sort_by(|a, b| {
                 if a == b {
                     return std::cmp::Ordering::Equal;
                 }

--- a/tables/src/lib.rs
+++ b/tables/src/lib.rs
@@ -73,7 +73,7 @@ pub fn print_tabular(
     };
     let nrows = rows.len();
     let mut ncols = 0;
-    for row in rows.iter().take(nrows) {
+    for row in &rows[0..nrows] {
         ncols = max(ncols, row.len());
     }
     let mut maxcol = vec![0; ncols];
@@ -176,7 +176,7 @@ pub fn print_tabular_vbox(
     let mut rrr = rows.to_owned();
     let nrows = rrr.len();
     let mut ncols = 0;
-    for item in rrr.iter().take(nrows) {
+    for item in &rrr[0..nrows] {
         ncols = max(ncols, item.len());
     }
     let mut vert = vec![false; ncols];
@@ -312,7 +312,7 @@ pub fn print_tabular_vbox(
 
     // Go through the rows.
 
-    for (i, row) in rrr.iter().take(nrows).enumerate() {
+    for (i, row) in rrr[0..nrows].iter().enumerate() {
         if debug_print {
             println!("now row {} = {}", i, row.iter().format(","));
             println!("0 - pushing │ onto row {i}");

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1542,10 +1542,10 @@ pub fn annotate_seq_core(
                     }
                 }
             }
-            let count_true = |bools: &[bool]| (bools[0..n]).iter().filter(|c| **c).count();
+            let count_true = |bools: &[bool]| bools.iter().filter(|c| **c).count();
 
-            let total1 = count_true(&cov1);
-            let total2 = count_true(&cov2);
+            let total1 = count_true(&cov1[0..n]);
+            let total2 = count_true(&cov2[0..n]);
 
             // Same as above but always exclude UTRs.
 
@@ -1569,8 +1569,8 @@ pub fn annotate_seq_core(
                 }
             }
 
-            let total1_nu = count_true(&cov1_nu);
-            let total2_nu = count_true(&cov2_nu);
+            let total1_nu = count_true(&cov1_nu[0..n]);
+            let total2_nu = count_true(&cov2_nu[0..n]);
 
             // Compute amount shared.
 

--- a/vdj_ann/src/refx.rs
+++ b/vdj_ann/src/refx.rs
@@ -180,8 +180,8 @@ pub fn make_vdj_ref_data_core(
                 refdata.segtype.push("?");
             }
         }
-        for j in 0..types.len() {
-            if rheaders2[i].contains(types[j]) {
+        for (j, type_) in types.iter().enumerate() {
+            if rheaders2[i].contains(type_) {
                 refdata.rtype[i] = j as i32;
             }
         }
@@ -226,8 +226,8 @@ pub fn make_vdj_ref_data_core(
 
     // Fill in id.
 
-    for i in 0..rheaders.len() {
-        refdata.id.push(rheaders[i].between("|", "|").force_i32());
+    for header in rheaders.iter() {
+        refdata.id.push(header.between("|", "|").force_i32());
     }
 
     // Extend the reference.
@@ -251,18 +251,18 @@ pub fn make_vdj_ref_data_core(
 
     // Determine which V segments have matching UTRs in the reference.
 
-    for t in 0..rheaders.len() {
-        if !rheaders[t].contains("segment") {
-            let name = rheaders[t].after("|").between("|", "|");
-            if rheaders[t].contains("UTR") {
+    for header in rheaders.iter() {
+        if !header.contains("segment") {
+            let name = header.after("|").between("|", "|");
+            if header.contains("UTR") {
                 refdata.has_utr.insert(name.to_string(), true);
             }
         }
     }
-    for t in 0..rheaders.len() {
-        if !rheaders[t].contains("segment") {
-            let name = rheaders[t].after("|").between("|", "|");
-            if rheaders[t].contains("V-REGION") {
+    for header in rheaders.iter() {
+        if !header.contains("segment") {
+            let name = header.after("|").between("|", "|");
+            if header.contains("V-REGION") {
                 refdata.has_utr.entry(name.to_string()).or_insert(false);
             }
         }

--- a/vdj_ann/src/transcript.rs
+++ b/vdj_ann/src/transcript.rs
@@ -308,20 +308,19 @@ pub fn junction_supp_core(
             idj += 1;
         }
         let mut mm = Vec::<(i32, i32)>::new();
-        for r in idi..idj {
-            let ida = ids[r];
-            let b = &reads[ida as usize];
+        for ida in &ids[idi..idj] {
+            let b = &reads[*ida as usize];
             if b.len() < k {
                 continue;
             }
             for j in 0..b.len() - k + 1 {
                 let z: Kmer20 = b.get_kmer(j);
                 let low = lower_bound1_3(&kmers_plus, &z) as usize;
-                for m in low..kmers_plus.len() {
-                    if kmers_plus[m].0 != z {
+                for kmer in &kmers_plus[low..] {
+                    if kmer.0 != z {
                         break;
                     }
-                    let p = kmers_plus[m].2 as usize;
+                    let p = kmer.2 as usize;
                     if j > 0 && p > 0 && b.get(j - 1) == jseq.get(p - 1) {
                         continue;
                     }

--- a/vdj_ann/src/vdj_features.rs
+++ b/vdj_ann/src/vdj_features.rs
@@ -337,8 +337,8 @@ pub fn cdr3_start(aa: &[u8], _chain_type: &str, _verbose: bool) -> usize {
     for j in aa.len().saturating_sub(nm + reach)..=aa.len().saturating_sub(nm) {
         let mut score = 0;
         for k in 0..nm {
-            for l in 0..motif.len() {
-                if aa[j + k] == motif[l][k] {
+            for m in motif {
+                if aa[j + k] == m[k] {
                     score += 1;
                     if aa[j + k] == b'Q' {
                         break;
@@ -360,8 +360,8 @@ pub fn cdr3_score(aa: &[u8], _chain_type: &str, _verbose: bool) -> usize {
     for j in aa.len().saturating_sub(nm + REACH)..=aa.len().saturating_sub(nm) {
         let mut score = 0;
         for k in 0..nm {
-            for l in 0..motif.len() {
-                if aa[j + k] == motif[l][k] {
+            for m in motif {
+                if aa[j + k] == m[k] {
                     score += 1;
                     if aa[j + k] == b'Q' {
                         break;

--- a/vdj_ann_ref/src/bin/build_supp_ref.rs
+++ b/vdj_ann_ref/src/bin/build_supp_ref.rs
@@ -92,8 +92,8 @@ fn main() {
     let mut rheaders = Vec::<String>::new();
     read_fasta_into_vec_dna_string_plus_headers(fasta, &mut refs, &mut rheaders);
     let mut to_chr = HashMap::new();
-    for i in 0..rheaders.len() {
-        let chr = rheaders[i].before(" ");
+    for (i, header) in rheaders.iter().enumerate() {
+        let chr = header.before(" ");
         to_chr.insert(chr.to_string(), i);
     }
 

--- a/vdj_ann_ref/src/bin/build_vdj_ref.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref.rs
@@ -255,9 +255,9 @@ fn parse_gtf_file(gtf: &str, demangle: &HashMap<String, String>, exons: &mut Vec
         // change it to CDS.
 
         let mut biotype = String::new();
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" gene_biotype") {
-                biotype = fields8[i].between("\"", "\"").to_string();
+        for field in &fields8 {
+            if field.starts_with(" gene_biotype") {
+                biotype = field.between("\"", "\"").to_string();
             }
         }
         let mut cat = fields[2];
@@ -286,9 +286,9 @@ fn parse_gtf_file(gtf: &str, demangle: &HashMap<String, String>, exons: &mut Vec
         // Get gene name and demangle.
 
         let mut gene = String::new();
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" gene_name") {
-                gene = fields8[i].between("\"", "\"").to_string();
+        for field in &fields8 {
+            if field.starts_with(" gene_name") {
+                gene = field.between("\"", "\"").to_string();
             }
         }
         gene = gene.to_uppercase();
@@ -334,18 +334,18 @@ fn parse_gtf_file(gtf: &str, demangle: &HashMap<String, String>, exons: &mut Vec
         // Get transcript name.
 
         let mut tr = String::new();
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" transcript_name") {
-                tr = fields8[i].between("\"", "\"").to_string();
+        for field in &fields8 {
+            if field.starts_with(" transcript_name") {
+                tr = field.between("\"", "\"").to_string();
             }
         }
 
         // Get transcript id.
 
         let mut trid = String::new();
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" transcript_id") {
-                trid = fields8[i].between("\"", "\"").to_string();
+        for field in &fields8 {
+            if field.starts_with(" transcript_id") {
+                trid = field.between("\"", "\"").to_string();
             }
         }
 
@@ -1057,15 +1057,15 @@ fn main() {
         let fields8: Vec<&str> = fields[8].split_terminator(';').collect();
         let (mut gene, mut gene2) = (String::new(), String::new());
         let mut biotype = String::new();
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with("Name=") {
-                gene = fields8[i].after("Name=").to_string();
+        for field in &fields8 {
+            if field.starts_with("Name=") {
+                gene = field.after("Name=").to_string();
             }
-            if fields8[i].starts_with("description=") {
-                gene2 = fields8[i].after("description=").to_string();
+            if field.starts_with("description=") {
+                gene2 = field.after("description=").to_string();
             }
-            if fields8[i].starts_with("biotype=") {
-                biotype = fields8[i].after("biotype=").to_string();
+            if field.starts_with("biotype=") {
+                biotype = field.after("biotype=").to_string();
             }
         }
 
@@ -1187,8 +1187,8 @@ fn main() {
     // Find the chromosomes that we're using.
 
     let mut all_chrs = Vec::<String>::new();
-    for k in 0..exons.len() {
-        all_chrs.push(exons[k].2.clone());
+    for exon in &exons {
+        all_chrs.push(exon.2.clone());
     }
     unique_sort(&mut all_chrs);
 
@@ -1234,8 +1234,8 @@ fn main() {
         refs.push(DnaString::from_dna_string(&last));
     }
     let mut to_chr = HashMap::new();
-    for i in 0..rheaders.len() {
-        to_chr.insert(rheaders[i].clone(), i);
+    for (i, header) in rheaders.iter().enumerate() {
+        to_chr.insert(header.clone(), i);
     }
 
     // Get the DNA sequences for the exons.
@@ -1245,10 +1245,10 @@ fn main() {
         t.elapsed().as_secs_f64()
     );
     let mut dna = Vec::<DnaString>::new();
-    for i in 0..exons.len() {
-        let chr = &exons[i].2;
+    for exon in &exons {
+        let chr = &exon.2;
         let chrid = to_chr[chr];
-        let (start, stop) = (exons[i].3, exons[i].4);
+        let (start, stop) = (exon.3, exon.4);
         let seq = refs[chrid].slice(start as usize, stop as usize).to_owned();
         dna.push(seq);
     }
@@ -1266,13 +1266,13 @@ fn main() {
     while i < exons.len() {
         let j = next_diff12_8(&exons, i as i32) as usize;
         let mut x = Vec::<DnaString>::new();
-        for k in i..j {
-            x.push(dna[k].clone());
+        for d in dna.iter().take(j).skip(i) {
+            x.push(d.clone());
         }
         if !exons[i].6 {
             x.reverse();
-            for k in 0..x.len() {
-                x[k] = x[k].rc().clone();
+            for item in &mut x {
+                *item = item.rc().clone();
             }
         }
         dnas.push((x, i, j));
@@ -1302,8 +1302,8 @@ fn main() {
                 }
                 if matches {
                     let (r, s) = (dnas[i - 1].1, dnas[i - 1].2);
-                    for k in r..s {
-                        to_delete[k] = true;
+                    for item in to_delete.iter_mut().take(s).skip(r) {
+                        *item = true;
                     }
                 }
             }
@@ -1322,8 +1322,8 @@ fn main() {
     while i < exons.len() {
         let j = next_diff12_8(&exons, i as i32) as usize;
         let mut fws = Vec::<bool>::new();
-        for k in i..j {
-            fws.push(exons[k].6);
+        for exon in exons.iter().take(j).skip(i) {
+            fws.push(exon.6);
         }
         unique_sort(&mut fws);
         assert!(fws.len() == 1);
@@ -1340,8 +1340,8 @@ fn main() {
         // ◼ NOT SURE WHAT THIS IS DOING NOW.
 
         let mut chrs = Vec::<String>::new();
-        for k in i..j {
-            chrs.push(exons[k].2.clone());
+        for exon in exons.iter().take(j).skip(i) {
+            chrs.push(exon.2.clone());
         }
         unique_sort(&mut chrs);
         let chr = chrs[0].clone();
@@ -1353,12 +1353,12 @@ fn main() {
 
         let mut seq = DnaString::new();
         let trid = &exons[i].7;
-        for k in i..j {
-            if exons[k].2 != chr {
+        for exon in exons.iter().take(j).skip(i) {
+            if exon.2 != chr {
                 continue;
             }
-            let (start, stop) = (exons[k].3, exons[k].4);
-            let cat = &exons[k].5;
+            let (start, stop) = (exon.3, exon.4);
+            let cat = &exon.5;
             if cat == "five_prime_utr" {
                 let seqx = refs[chrid].slice(start as usize, stop as usize);
                 for i in 0..seqx.len() {
@@ -1384,12 +1384,12 @@ fn main() {
         {
             let mut seq = DnaString::new();
             let mut ncodons = 0;
-            for k in i..j {
-                if exons[k].2 != chr {
+            for exon in exons.iter().take(j).skip(i) {
+                if exon.2 != chr {
                     continue;
                 }
-                let (start, stop) = (exons[k].3, exons[k].4);
-                let cat = &exons[k].5;
+                let (start, stop) = (exon.3, exon.4);
+                let cat = &exon.5;
                 if cat == "CDS" {
                     ncodons += 1;
                     let seqx = refs[chrid].slice(start as usize, stop as usize);
@@ -1447,8 +1447,8 @@ fn main() {
             && gene != "IGHD"
         {
             let mut using = Vec::<usize>::new();
-            for k in i..j {
-                if exons[k].2 == chr && exons[k].5 != "five_prime_utr" {
+            for (k, exon) in exons.iter().enumerate().take(j).skip(i) {
+                if exon.2 == chr && exon.5 != "five_prime_utr" {
                     using.push(k);
                 }
             }
@@ -1497,11 +1497,11 @@ fn main() {
                 gene = format!("TRG{}", gene.after("TRGC"));
             }
             let mut seq = DnaString::new();
-            for k in i..j {
-                if exons[k].2 != chr {
+            for exon in exons.iter().take(j).skip(i) {
+                if exon.2 != chr {
                     continue;
                 }
-                let (start, stop) = (exons[k].3, exons[k].4);
+                let (start, stop) = (exon.3, exon.4);
                 let seqx = refs[chrid].slice(start as usize, stop as usize);
                 for i in 0..seqx.len() {
                     seq.push(seqx.get(i));
@@ -1531,46 +1531,46 @@ fn main() {
         "{:.1} seconds used, adding genes",
         t.elapsed().as_secs_f64()
     );
-    for i in 0..added_genes.len() {
+    for gene in added_genes {
         add_gene(
             &mut out,
-            added_genes[i].0,
+            gene.0,
             &mut record,
-            added_genes[i].1,
-            added_genes[i].2,
-            added_genes[i].3,
+            gene.1,
+            gene.2,
+            gene.3,
             &to_chr,
             &refs,
             none,
-            added_genes[i].4,
+            gene.4,
             &source,
         );
     }
-    for i in 0..added_genes2.len() {
+    for gene in added_genes2 {
         add_gene2(
             &mut out,
-            added_genes2[i].0,
+            gene.0,
             &mut record,
-            added_genes2[i].1,
-            added_genes2[i].2,
-            added_genes2[i].3,
-            added_genes2[i].4,
-            added_genes2[i].5,
+            gene.1,
+            gene.2,
+            gene.3,
+            gene.4,
+            gene.5,
             &to_chr,
             &refs,
             none,
-            added_genes2[i].6,
+            gene.6,
             &source,
         );
     }
-    for i in 0..added_genes2_source.len() {
-        let gene = &added_genes2_source[i].0;
-        let start1 = added_genes2_source[i].1;
-        let stop1 = added_genes2_source[i].2;
-        let start2 = added_genes2_source[i].3;
-        let stop2 = added_genes2_source[i].4;
-        let fw = added_genes2_source[i].5;
-        let source = &added_genes2_source[i].6;
+    for added_gene in added_genes2_source {
+        let gene = &added_gene.0;
+        let start1 = added_gene.1;
+        let stop1 = added_gene.2;
+        let start2 = added_gene.3;
+        let stop2 = added_gene.4;
+        let fw = added_gene.5;
+        let source = &added_gene.6;
         let mut seq = DnaString::new();
         load_genbank_accession(source, &mut seq);
         let seq1 = seq.slice(start1 - 1, stop1);
@@ -1585,9 +1585,9 @@ fn main() {
         let header = header_from_gene(gene, false, &mut record, source);
         print_fasta(&mut out, &header, &seq.slice(0, seq.len()), none);
     }
-    for i in 0..added_genes_seq.len() {
-        let gene = &added_genes_seq[i].0;
-        let seq = DnaString::from_dna_string(added_genes_seq[i].1);
+    for added_gene in added_genes_seq {
+        let gene = added_gene.0;
+        let seq = DnaString::from_dna_string(added_gene.1);
         let header = header_from_gene(gene, false, &mut record, &source);
         print_fasta(&mut out, &header, &seq.slice(0, seq.len()), none);
     }

--- a/vdj_ann_ref/src/bin/build_vdj_ref.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref.rs
@@ -1266,7 +1266,7 @@ fn main() {
     while i < exons.len() {
         let j = next_diff12_8(&exons, i as i32) as usize;
         let mut x = Vec::<DnaString>::new();
-        for d in dna.iter().take(j).skip(i) {
+        for d in &dna[i..j] {
             x.push(d.clone());
         }
         if !exons[i].6 {
@@ -1302,7 +1302,7 @@ fn main() {
                 }
                 if matches {
                     let (r, s) = (dnas[i - 1].1, dnas[i - 1].2);
-                    for item in to_delete.iter_mut().take(s).skip(r) {
+                    for item in &mut to_delete[r..s] {
                         *item = true;
                     }
                 }
@@ -1322,7 +1322,7 @@ fn main() {
     while i < exons.len() {
         let j = next_diff12_8(&exons, i as i32) as usize;
         let mut fws = Vec::<bool>::new();
-        for exon in exons.iter().take(j).skip(i) {
+        for exon in &exons[i..j] {
             fws.push(exon.6);
         }
         unique_sort(&mut fws);
@@ -1340,7 +1340,7 @@ fn main() {
         // ◼ NOT SURE WHAT THIS IS DOING NOW.
 
         let mut chrs = Vec::<String>::new();
-        for exon in exons.iter().take(j).skip(i) {
+        for exon in &exons[i..j] {
             chrs.push(exon.2.clone());
         }
         unique_sort(&mut chrs);
@@ -1353,7 +1353,7 @@ fn main() {
 
         let mut seq = DnaString::new();
         let trid = &exons[i].7;
-        for exon in exons.iter().take(j).skip(i) {
+        for exon in &exons[i..j] {
             if exon.2 != chr {
                 continue;
             }
@@ -1384,7 +1384,7 @@ fn main() {
         {
             let mut seq = DnaString::new();
             let mut ncodons = 0;
-            for exon in exons.iter().take(j).skip(i) {
+            for exon in &exons[i..j] {
                 if exon.2 != chr {
                     continue;
                 }
@@ -1447,8 +1447,9 @@ fn main() {
             && gene != "IGHD"
         {
             let mut using = Vec::<usize>::new();
-            for (k, exon) in exons.iter().enumerate().take(j).skip(i) {
-                if exon.2 == chr && exon.5 != "five_prime_utr" {
+            #[allow(clippy::needless_range_loop)]
+            for k in i..j {
+                if exons[k].2 == chr && exons[k].5 != "five_prime_utr" {
                     using.push(k);
                 }
             }
@@ -1497,7 +1498,7 @@ fn main() {
                 gene = format!("TRG{}", gene.after("TRGC"));
             }
             let mut seq = DnaString::new();
-            for exon in exons.iter().take(j).skip(i) {
+            for exon in &exons[i..j] {
                 if exon.2 != chr {
                     continue;
                 }

--- a/vdj_ann_ref/src/bin/build_vdj_ref_exons.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref_exons.rs
@@ -67,9 +67,9 @@ fn parse_gtf_file(gtf: &str, demangle: &HashMap<String, String>, exons: &mut Vec
         // change it to CDS. [NOT]
 
         let mut biotype = String::new();
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" gene_biotype") {
-                biotype = fields8[i].between("\"", "\"").to_string();
+        for field in &fields8 {
+            if field.starts_with(" gene_biotype") {
+                biotype = field.between("\"", "\"").to_string();
             }
         }
         let cat = fields[2];
@@ -89,9 +89,9 @@ fn parse_gtf_file(gtf: &str, demangle: &HashMap<String, String>, exons: &mut Vec
         // Get gene name and demangle.
 
         let mut gene = "";
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" gene_name") {
-                gene = fields8[i].between("\"", "\"");
+        for field in &fields8 {
+            if field.starts_with(" gene_name") {
+                gene = field.between("\"", "\"");
             }
         }
         let gene = gene.to_uppercase();
@@ -139,18 +139,18 @@ fn parse_gtf_file(gtf: &str, demangle: &HashMap<String, String>, exons: &mut Vec
         // Get transcript name.
 
         let mut tr = "";
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" transcript_name") {
-                tr = fields8[i].between("\"", "\"");
+        for field in &fields8 {
+            if field.starts_with(" transcript_name") {
+                tr = field.between("\"", "\"");
             }
         }
 
         // Get transcript id.
 
         let mut trid = "";
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with(" transcript_id") {
-                trid = fields8[i].between("\"", "\"");
+        for field in &fields8 {
+            if field.starts_with(" transcript_id") {
+                trid = field.between("\"", "\"");
             }
         }
 
@@ -698,15 +698,15 @@ fn main() {
         let fields8: Vec<&str> = fields[8].split_terminator(';').collect();
         let (mut gene, mut gene2) = (String::new(), String::new());
         let mut biotype = String::new();
-        for i in 0..fields8.len() {
-            if fields8[i].starts_with("Name=") {
-                gene = fields8[i].after("Name=").to_string();
+        for field in &fields8 {
+            if field.starts_with("Name=") {
+                gene = field.after("Name=").to_string();
             }
-            if fields8[i].starts_with("description=") {
-                gene2 = fields8[i].after("description=").to_string();
+            if field.starts_with("description=") {
+                gene2 = field.after("description=").to_string();
             }
-            if fields8[i].starts_with("biotype=") {
-                biotype = fields8[i].after("biotype=").to_string();
+            if field.starts_with("biotype=") {
+                biotype = field.after("biotype=").to_string();
             }
         }
 
@@ -828,8 +828,8 @@ fn main() {
     // Find the chromosomes that we're using.
 
     let mut all_chrs = Vec::<String>::new();
-    for k in 0..exons.len() {
-        all_chrs.push(exons[k].2.clone());
+    for exon in &exons {
+        all_chrs.push(exon.2.clone());
     }
     unique_sort(&mut all_chrs);
 
@@ -871,8 +871,8 @@ fn main() {
         refs.push(DnaString::from_dna_string(&last));
     }
     let mut to_chr = HashMap::new();
-    for i in 0..rheaders.len() {
-        to_chr.insert(rheaders[i].clone(), i);
+    for (i, header) in rheaders.iter().enumerate() {
+        to_chr.insert(header.clone(), i);
     }
 
     // Get the DNA sequences for the exons.  Extended by ten in both directions.
@@ -881,12 +881,12 @@ fn main() {
     let mut dna = Vec::<DnaString>::new();
     let mut starts = Vec::<usize>::new();
     let mut stops = Vec::<usize>::new();
-    for i in 0..exons.len() {
-        let chr = &exons[i].2;
+    for exon in &exons {
+        let chr = &exon.2;
         let chrid = to_chr[chr];
-        starts.push(exons[i].3 as usize);
-        stops.push(exons[i].4 as usize);
-        let (start, stop) = (exons[i].3 - EXT as i32, exons[i].4 + EXT as i32);
+        starts.push(exon.3 as usize);
+        stops.push(exon.4 as usize);
+        let (start, stop) = (exon.3 - EXT as i32, exon.4 + EXT as i32);
         let seq = refs[chrid].slice(start as usize, stop as usize).to_owned();
         dna.push(seq);
     }

--- a/vdj_ann_ref/src/lib.rs
+++ b/vdj_ann_ref/src/lib.rs
@@ -144,8 +144,8 @@ mod tests {
         let mut ann = Vec::<Annotation>::new();
         annotate_seq(&seq, &refdata, &mut ann, true, false, true);
         let mut have_d = false;
-        for i in 0..ann.len() {
-            if refdata.is_d(ann[i].ref_id as usize) {
+        for a in ann {
+            if refdata.is_d(a.ref_id as usize) {
                 have_d = true;
             }
         }


### PR DESCRIPTION
Remove the exception to the `clippy::needless_range_loop` lint and fix many violations.

I've validated this changeset by running enclone and cellranger's CI against it.  Note that this did catch several bugs introduced in the annotation code, which I subsequently fixed.  The changes in that file should be reviewed particularly closely.