### PR TITLE
Create structs for internal annotation tuples

### DIFF
--- a/enclone/src/allele.rs
+++ b/enclone/src/allele.rs
@@ -115,7 +115,7 @@ pub fn find_alleles(
         let mut alls = Vec::<Vec<(usize, Vec<u8>, Vec<usize>, usize, usize, String)>>::new();
         let mut i = 0;
         while i < allx.len() {
-            // let j = next_diff1_6(&allx, i as i32) as usize;
+            // let j = next_diff1_6(&allx, i);
             let mut j = i + 1;
             while j < allx.len() {
                 if allx[j].0 != allx[i].0 {
@@ -188,7 +188,7 @@ pub fn find_alleles(
                 trace.sort_unstable();
                 let mut i = 0;
                 while i < trace.len() {
-                    let j = next_diff1_2(&trace, i as i32) as usize;
+                    let j = next_diff1_2(&trace, i);
                     for k in i..j {
                         if !to_delete[trace[k].1] {
                             for l in i..j {
@@ -223,7 +223,7 @@ pub fn find_alleles(
                 let mut freqs = Vec::<(usize, Vec<usize>, Vec<Vec<usize>>, u8)>::new();
                 let mut i = 0;
                 while i < bases.len() {
-                    let j = next_diff1_3(&bases, i as i32) as usize;
+                    let j = next_diff1_3(&bases, i);
                     let mut x = Vec::<usize>::new();
                     let mut y = Vec::<Vec<usize>>::new();
                     for base in &bases[i..j] {
@@ -297,7 +297,7 @@ pub fn find_alleles(
             let mut i = 0;
             let mut have_ref = false;
             while i < types.len() {
-                let j = next_diff1_2(&types, i as i32) as usize;
+                let j = next_diff1_2(&types, i);
 
                 // Determine if the contigs equal reference at the positions in ps.
 

--- a/enclone/src/graph_filter.rs
+++ b/enclone/src/graph_filter.rs
@@ -97,7 +97,7 @@ pub fn graph_filter(
     let mut edges1 = Vec::<(usize, usize, (usize, usize))>::new();
     let mut i = 0;
     while i < edges0.len() {
-        let j = next_diff12_3(&edges0, i as i32) as usize;
+        let j = next_diff12_3(&edges0, i);
         let mut weight = 0;
         for e in &edges0[i..j] {
             weight += e.2;

--- a/enclone/src/join.rs
+++ b/enclone/src/join.rs
@@ -55,7 +55,7 @@ pub fn join_exacts(
         bcx.sort();
         let mut i = 0;
         while i < bcx.len() {
-            let j = next_diff1_2(&bcx, i as i32) as usize;
+            let j = next_diff1_2(&bcx, i);
             for k in i + 1..j {
                 eq.join(bcx[i].1 as i32, bcx[k].1 as i32);
             }

--- a/enclone/src/join2.rs
+++ b/enclone/src/join2.rs
@@ -76,7 +76,7 @@ pub fn finish_join(
     ox.sort_unstable();
     let mut i = 0;
     while i < ox.len() {
-        let j = next_diff1_2(&ox, i as i32) as usize;
+        let j = next_diff1_2(&ox, i);
         for k in i..j - 1 {
             eq.join(ox[k].1, ox[k + 1].1);
         }

--- a/enclone/src/misc1.rs
+++ b/enclone/src/misc1.rs
@@ -137,7 +137,7 @@ pub fn lookup_heavy_chain_reuse(
                 xcdr3.sort();
                 let mut i = 0;
                 while i < xcdr3.len() {
-                    let j = next_diff1_3(&xcdr3, i as i32) as usize;
+                    let j = next_diff1_3(&xcdr3, i);
                     let mut ids = Vec::<usize>::new();
                     for cdr in &xcdr3[i..j] {
                         ids.push(cdr.2);
@@ -266,7 +266,7 @@ pub fn cross_filter(
     let mut blacklist = Vec::<&[u8]>::new();
     let mut i = 0;
     while i < vjx.len() {
-        let j = next_diff1_3(&vjx, i as i32) as usize;
+        let j = next_diff1_3(&vjx, i);
         if j - i == 1 {
             let dataset_index = vjx[i].1;
             let n = vjx[i].2;

--- a/enclone/src/misc2.rs
+++ b/enclone/src/misc2.rs
@@ -52,7 +52,7 @@ pub fn filter_gelbead_contamination(
         bch[l].sort_unstable();
         let mut m = 0;
         while m < bch[l].len() {
-            let n = next_diff12_4(&bch[l], m as i32) as usize;
+            let n = next_diff12_4(&bch[l], m);
             let mut count = 0;
             for u1 in m..n {
                 for u2 in m..n {
@@ -121,7 +121,7 @@ pub fn create_exact_subclonotype_core(
             let mut callsx = Vec::<(usize, u8)>::new(); // (qual,base)
             let mut i = 0;
             while i < calls.len() {
-                let j = next_diff1_2(&calls, i as i32) as usize;
+                let j = next_diff1_2(&calls, i);
                 let mut q = 0;
                 for c in &calls[i..j] {
                     q += c.1 as usize;
@@ -156,7 +156,7 @@ pub fn create_exact_subclonotype_core(
             let mut callsx = Vec::<(usize, u8)>::new(); // (qual,base)
             let mut i = 0;
             while i < calls.len() {
-                let j = next_diff1_2(&calls, i as i32) as usize;
+                let j = next_diff1_2(&calls, i);
                 let mut q = 0;
                 for c in &calls[i..j] {
                     q += c.1 as usize;
@@ -373,7 +373,7 @@ pub fn find_exact_subclonotypes(
         bc.sort_unstable();
         let mut i = 0;
         while i < bc.len() {
-            let j = next_diff1_2(&bc, i as i32) as usize;
+            let j = next_diff1_2(&bc, i);
             if j - i >= 2 {
                 for bck in &bc[i..j] {
                     let t = bck.1;
@@ -535,7 +535,7 @@ pub fn search_for_shm_indels(ctl: &EncloneControl, tig_bc: &[Vec<TigData>]) {
         unique_sort(&mut cs);
         let mut i = 0;
         while i < cs.len() {
-            let j = next_diff1_3(&cs, i as i32) as usize;
+            let j = next_diff1_3(&cs, i);
             if j - i > 1 {
                 println!("{}", cs[i].2);
             }
@@ -566,7 +566,7 @@ pub fn check_for_barcode_reuse(
         let mut reuse = Vec::<(usize, usize)>::new();
         let mut i = 0;
         while i < all.len() {
-            let j = next_diff1_3(&all, i as i32) as usize;
+            let j = next_diff1_3(&all, i);
             for k1 in i..j {
                 for k2 in k1 + 1..j {
                     // We require identity on one cdr3_aa.  That seems to be about the right amount

--- a/enclone/src/secret.rs
+++ b/enclone/src/secret.rs
@@ -209,11 +209,11 @@ pub fn fetch_secmem(ctl: &mut EncloneControl) -> Result<(), String> {
         data.sort();
         let mut i = 0;
         while i < data.len() {
-            let j = next_diff1_3(&data, i as i32) as usize;
+            let j = next_diff1_3(&data, i);
             let (mut sec, mut mem) = (0, 0);
             let mut k = i;
             while k < j {
-                // let l = next_diff12_3(&data, k as i32) as usize; // crashed loader
+                // let l = next_diff12_3(&data, k); // crashed loader
                 let mut l = k;
                 while l < j {
                     if data[l].1 != data[k].1 {

--- a/enclone_print/src/define_mat.rs
+++ b/enclone_print/src/define_mat.rs
@@ -41,7 +41,7 @@ fn joiner(
     }
     let mut i = 0;
     while i < seq_chains.len() {
-        let j = next_diff1_3(seq_chains, i as i32) as usize;
+        let j = next_diff1_3(seq_chains, i);
         for k in i + 1..j {
             let (x1, x2) = (&seq_chains[i], &seq_chains[k]);
             let z1 = bin_position(chains, &(x1.1, x1.2));
@@ -66,7 +66,7 @@ pub fn setup_define_mat(orbit: &[i32], info: &[CloneInfo]) -> (Vec<Od>, Vec<usiz
     let mut exacts = Vec::<usize>::new();
     let mut j = 0;
     while j < od.len() {
-        let k = next_diff12_3(&od, j as i32) as usize;
+        let k = next_diff12_3(&od, j);
         exacts.push(od[j].1);
         j = k;
     }
@@ -229,7 +229,7 @@ pub fn define_mat(
     let mut rxir = Vec::<(usize, usize, usize)>::new(); // (heavy orbit, light orbit, info index)
     let mut i = 0;
     while i < rxi.len() {
-        let j = next_diff12_3(&rxi, i as i32) as usize;
+        let j = next_diff12_3(&rxi, i);
         rxir.extend(&rxi[i..j.min(i + MAX_USE)]);
         i = j;
     }

--- a/enclone_print/src/loupe.rs
+++ b/enclone_print/src/loupe.rs
@@ -36,7 +36,7 @@ pub fn make_donor_refs(
             }
             j += 1;
         }
-        // let j = next_diff12_5(alt_refs, i as i32) as usize;
+        // let j = next_diff12_5(alt_refs, i);
         for (k, x) in alt_refs.iter().enumerate().take(j).skip(i) {
             let donor_id = x.0;
             let ref_id = x.1;

--- a/enclone_print/src/print_clonotypes.rs
+++ b/enclone_print/src/print_clonotypes.rs
@@ -229,7 +229,7 @@ pub fn print_clonotypes(
         let mut mults = Vec::<usize>::new();
         let mut j = 0;
         while j < od.len() {
-            let k = next_diff12_3(&od, j as i32) as usize;
+            let k = next_diff12_3(&od, j);
             let mut mult = 0_usize;
             for l in j..k {
                 let x: &CloneInfo = &info[od[l].2 as usize];

--- a/enclone_print/src/print_utils2.rs
+++ b/enclone_print/src/print_utils2.rs
@@ -172,7 +172,7 @@ pub fn row_fill(
             bch[l].sort();
             let mut m = 0;
             while m < bch[l].len() {
-                let n = next_diff12_4(&bch[l], m as i32) as usize;
+                let n = next_diff12_4(&bch[l], m);
                 for u1 in m..n {
                     for u2 in m..n {
                         if bch[l][u1].2 >= 10 * bch[l][u2].2 {

--- a/enclone_print/src/proc_cvar_auto.rs
+++ b/enclone_print/src/proc_cvar_auto.rs
@@ -1466,7 +1466,7 @@ pub fn proc_cvar_auto(
             bch[l].sort();
             let mut m = 0;
             while m < bch[l].len() {
-                let n = next_diff12_4(&bch[l], m as i32) as usize;
+                let n = next_diff12_4(&bch[l], m);
                 for u1 in m..n {
                     for u2 in m..n {
                         if bch[l][u1].2 >= 10 * bch[l][u2].2 {

--- a/enclone_stuff/src/analyze_dref.rs
+++ b/enclone_stuff/src/analyze_dref.rs
@@ -75,7 +75,7 @@ pub fn analyze_donor_ref(
         refs.sort();
         let mut i = 0;
         while i < refs.len() {
-            let j = next_diff1_3(&refs, i as i32) as usize;
+            let j = next_diff1_3(&refs, i);
             let gene = &refs[i].0;
             let mut alleles = Vec::<(&[u8], &str)>::new(); // (sequence, name)
             let mut have_alt = false;
@@ -128,7 +128,7 @@ pub fn analyze_donor_ref(
                 let mut allelesg = Vec::<(Vec<&str>, &[u8])>::new();
                 let mut r = 0;
                 while r < alleles.len() {
-                    let s = next_diff1_2(&alleles, r as i32) as usize;
+                    let s = next_diff1_2(&alleles, r);
                     let mut names = Vec::<&str>::new();
                     for at in &alleles[r..s] {
                         names.push(at.1);

--- a/enclone_stuff/src/doublets.rs
+++ b/enclone_stuff/src/doublets.rs
@@ -113,7 +113,7 @@ pub fn delete_doublets(
 
             let mut j = 0;
             while j < content.len() {
-                let k = next_diff1_2(&content, j as i32) as usize;
+                let k = next_diff1_2(&content, j);
                 for l1 in j..k {
                     for l2 in l1 + 1..k {
                         shares.push((content[l1].1, content[l2].1));

--- a/enclone_stuff/src/filter_umi.rs
+++ b/enclone_stuff/src/filter_umi.rs
@@ -271,7 +271,7 @@ pub fn filter_umi(
                 reverse_sort(&mut z);
                 let mut j = 0;
                 while j < z.len() {
-                    let k = next_diff1_5(&z, j as i32) as usize;
+                    let k = next_diff1_5(&z, j);
                     for l in j..k {
                         if z[j].1 >= MIN_UMI_RATIO * z[l].4 {
                             to_delete[z[l].2][z[l].3] = true;

--- a/enclone_stuff/src/some_filters.rs
+++ b/enclone_stuff/src/some_filters.rs
@@ -97,7 +97,7 @@ pub fn some_filters(
             types.sort();
             let mut i = 0;
             while i < types.len() {
-                let j = next_diff1_2(&types, i as i32) as usize;
+                let j = next_diff1_2(&types, i);
                 let mut mult = 0;
                 for t in &types[i..j] {
                     mult += t.1;

--- a/enclone_stuff/src/start.rs
+++ b/enclone_stuff/src/start.rs
@@ -631,7 +631,7 @@ pub fn main_enclone_start(setup: EncloneSetup) -> Result<EncloneIntermediates, S
                 od.sort();
                 let mut j = 0;
                 while j < od.len() {
-                    let k = next_diff12_3(&od, j as i32) as usize;
+                    let k = next_diff12_3(&od, j);
                     res.1.push(od[j].1);
                     j = k;
                 }

--- a/enclone_vars/src/vars
+++ b/enclone_vars/src/vars
@@ -3890,7 +3890,7 @@ code:     let mut bch = vec![Vec::<(usize, String, usize, usize)>::new(); 2];
               bch[l].sort();
               let mut m = 0;
               while m < bch[l].len() {
-                  let n = next_diff12_4(&bch[l], m as i32) as usize;
+                  let n = next_diff12_4(&bch[l], m);
                   for u1 in m..n {
                       for u2 in m..n {
                           if bch[l][u1].2 >= 10 * bch[l][u2].2 {

--- a/hyperbase/src/lib.rs
+++ b/hyperbase/src/lib.rs
@@ -191,8 +191,7 @@ impl HyperBasevector {
         let mut i: i64 = 0;
         let mut dups = 0;
         while i < kmers_plus.len() as i64 {
-            // warning: note truncation to i32
-            let j = next_diff1_3(&kmers_plus, i as i32) as i64;
+            let j = next_diff1_3(&kmers_plus, i as usize) as i64;
             if j - i > 1 {
                 if dups == 0 {
                     println!("\ntest_unique failed");

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -2091,13 +2091,10 @@ pub fn annotate_seq_core(
                     best_matches = max(best_matches, result.1);
                 }
                 if results[0].1 == best_matches {
-                    let t = results[0].2;
-                    let r = results[0].0 + results[0].1;
-                    let m = results[0].4;
                     annx.push(PreAnnotation {
-                        tig_start: m as i32,
-                        match_len: r as i32,
-                        ref_id: t as i32,
+                        tig_start: results[0].4 as i32,
+                        match_len: (results[0].0 + results[0].1) as i32,
+                        ref_id: results[0].2 as i32,
                         ref_start: 0,
                         mismatches: results[0].5.clone(),
                     });

--- a/vdj_ann_ref/src/bin/build_vdj_ref.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref.rs
@@ -1264,7 +1264,7 @@ fn main() {
     let mut i = 0;
     let mut dnas = Vec::<(Vec<DnaString>, usize, usize)>::new();
     while i < exons.len() {
-        let j = next_diff12_8(&exons, i as i32) as usize;
+        let j = next_diff12_8(&exons, i);
         let mut x = Vec::<DnaString>::new();
         for d in &dna[i..j] {
             x.push(d.clone());
@@ -1320,7 +1320,7 @@ fn main() {
     let mut i = 0;
     let mut record = 0;
     while i < exons.len() {
-        let j = next_diff12_8(&exons, i as i32) as usize;
+        let j = next_diff12_8(&exons, i);
         let mut fws = Vec::<bool>::new();
         for exon in &exons[i..j] {
             fws.push(exon.6);

--- a/vector_utils/src/lib.rs
+++ b/vector_utils/src/lib.rs
@@ -333,140 +333,75 @@ pub fn count_instances<T: Ord + ?Sized>(x: &[impl Borrow<T>], d: &T) -> i32 {
 // NEXT DIFFERENCE
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
+pub fn next_diff_any<T>(x: &[T], i: usize, eq: impl Fn(&T, &T) -> bool) -> usize {
+    let mut j = i + 1;
+    loop {
+        if j == x.len() || !eq(&x[j], &x[i]) {
+            return j;
+        }
+        j += 1;
+    }
+}
+
 // Find first element that's different in a sorted vector, or different in
 // first position.
 
 pub fn next_diff<T: Eq>(x: &[T], i: usize) -> usize {
-    let mut j = i + 1;
-    loop {
-        if j == x.len() || x[j] != x[i] {
-            return j;
-        }
-        j += 1;
-    }
+    next_diff_any(x, i, |a, b| a == b)
 }
 
-pub fn next_diff1_2<T: Eq, U: Eq>(x: &[(T, U)], i: i32) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32 || x[j as usize].0 != x[i as usize].0 {
-            return j;
-        }
-        j += 1;
-    }
+pub fn next_diff1_2<T: Eq, U: Eq>(x: &[(T, U)], i: usize) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0)
 }
 
-pub fn next_diff1_3<T: Eq, U: Eq, V: Eq>(x: &[(T, U, V)], i: i32) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32 || x[j as usize].0 != x[i as usize].0 {
-            return j;
-        }
-        j += 1;
-    }
+pub fn next_diff1_3<T: Eq, U: Eq, V: Eq>(x: &[(T, U, V)], i: usize) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0)
 }
 
-pub fn next_diff1_4<T: Eq, U: Eq, V: Eq, W: Eq>(x: &[(T, U, V, W)], i: i32) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32 || x[j as usize].0 != x[i as usize].0 {
-            return j;
-        }
-        j += 1;
-    }
+pub fn next_diff1_4<T: Eq, U: Eq, V: Eq, W: Eq>(x: &[(T, U, V, W)], i: usize) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0)
 }
 
-pub fn next_diff12_3<T: Eq, U: Eq, V: Eq>(x: &[(T, U, V)], i: i32) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32
-            || x[j as usize].0 != x[i as usize].0
-            || x[j as usize].1 != x[i as usize].1
-        {
-            return j;
-        }
-        j += 1;
-    }
+pub fn next_diff12_3<T: Eq, U: Eq, V: Eq>(x: &[(T, U, V)], i: usize) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0 && a.1 == b.1)
 }
 
-pub fn next_diff12_4<T: Eq, U: Eq, V: Eq, W: Eq>(x: &[(T, U, V, W)], i: i32) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32
-            || x[j as usize].0 != x[i as usize].0
-            || x[j as usize].1 != x[i as usize].1
-        {
-            return j;
-        }
-        j += 1;
-    }
+pub fn next_diff12_4<T: Eq, U: Eq, V: Eq, W: Eq>(x: &[(T, U, V, W)], i: usize) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0 && a.1 == b.1)
 }
 
 #[allow(clippy::type_complexity)]
 pub fn next_diff12_8<S: Eq, T: Eq, U: Eq, V: Eq, W: Eq, X: Eq, Y: Eq, Z: Eq>(
     x: &[(S, T, U, V, W, X, Y, Z)],
-    i: i32,
-) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32
-            || x[j as usize].0 != x[i as usize].0
-            || x[j as usize].1 != x[i as usize].1
-        {
-            return j;
-        }
-        j += 1;
-    }
+    i: usize,
+) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0 && a.1 == b.1)
 }
 
-pub fn next_diff1_5<T: Eq, U: Eq, V: Eq, W: Eq, X: Eq>(x: &[(T, U, V, W, X)], i: i32) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32 || x[j as usize].0 != x[i as usize].0 {
-            return j;
-        }
-        j += 1;
-    }
+pub fn next_diff1_5<T: Eq, U: Eq, V: Eq, W: Eq, X: Eq>(x: &[(T, U, V, W, X)], i: usize) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0)
 }
 
 pub fn next_diff1_6<T: Eq, U: Eq, V: Eq, W: Eq, X: Eq, Y: Eq>(
     x: &[(T, U, V, W, X, Y)],
-    i: i32,
-) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32 || x[j as usize].0 != x[i as usize].0 {
-            return j;
-        }
-        j += 1;
-    }
+    i: usize,
+) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0)
 }
 
 pub fn next_diff1_7<T: Eq, U: Eq, V: Eq, W: Eq, X: Eq, Y: Eq, Z: Eq>(
     x: &[(T, U, V, W, X, Y, Z)],
-    i: i32,
-) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32 || x[j as usize].0 != x[i as usize].0 {
-            return j;
-        }
-        j += 1;
-    }
+    i: usize,
+) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0)
 }
 
 #[allow(clippy::type_complexity)]
 pub fn next_diff1_8<S: Eq, T: Eq, U: Eq, V: Eq, W: Eq, X: Eq, Y: Eq, Z: Eq>(
     x: &[(S, T, U, V, W, X, Y, Z)],
-    i: i32,
-) -> i32 {
-    let mut j: i32 = i + 1;
-    loop {
-        if j == x.len() as i32 || x[j as usize].0 != x[i as usize].0 {
-            return j;
-        }
-        j += 1;
-    }
+    i: usize,
+) -> usize {
+    next_diff_any(x, i, |a, b| a.0 == b.0)
 }
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓

--- a/vector_utils/src/lib.rs
+++ b/vector_utils/src/lib.rs
@@ -333,6 +333,8 @@ pub fn count_instances<T: Ord + ?Sized>(x: &[impl Borrow<T>], d: &T) -> i32 {
 // NEXT DIFFERENCE
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
+/// Find first element that's different in a sorted vector, or different in
+/// first position.
 pub fn next_diff_any<T>(x: &[T], i: usize, eq: impl Fn(&T, &T) -> bool) -> usize {
     let mut j = i + 1;
     loop {
@@ -342,9 +344,6 @@ pub fn next_diff_any<T>(x: &[T], i: usize, eq: impl Fn(&T, &T) -> bool) -> usize
         j += 1;
     }
 }
-
-// Find first element that's different in a sorted vector, or different in
-// first position.
 
 pub fn next_diff<T: Eq>(x: &[T], i: usize) -> usize {
     next_diff_any(x, i, |a, b| a == b)


### PR DESCRIPTION
Refactors several tuples in the main annotation function into structs.
As part of this I created a generic implementation of the `vec_utils::find_next*` functions, re-implemented all of the existing functions using the generic version, and fixed the input and output types to be usize (and fixed all the calling locations).