### PR TITLE
break up main annotation function into small pieces

### DIFF
--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -254,6 +254,11 @@ fn report_semis(
 }
 
 // TODO: combine this and the PreAnnotation type above?
+// This is tricky, though, as both types derive sorting, and the order of fields
+// implies different sort ordering. Probably the best way to address this is to
+// remove the derivation of eq/ord, provide key-generating methods with
+// explicit names, and use those. This forces the caller to be explicit about
+// which sort order they're using.
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct PerfectMatch {
     pub ref_id: i32,
@@ -264,6 +269,12 @@ struct PerfectMatch {
     pub len: i32,
 }
 
+// TODO: combine this and the PreAnnotation type above?
+// This is tricky, though, as both types derive sorting, and the order of fields
+// implies different sort ordering. Probably the best way to address this is to
+// remove the derivation of eq/ord, provide key-generating methods with
+// explicit names, and use those. This forces the caller to be explicit about
+// which sort order they're using.
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 struct SemiPerfectMatch {
     pub ref_id: i32,

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -315,9 +315,6 @@ pub fn annotate_seq_core(
     // we found when profiling the CI job.  To avoid those in the inner
     // loop, we unpack it once here:
     let b_seq = b.to_bytes();
-    // Unpack refdata.
-
-    let refs = &refdata.refs;
 
     if b.len() < K {
         return;
@@ -358,7 +355,14 @@ pub fn annotate_seq_core(
     }
 
     let mut semi = merge_perfect_matches(&b_seq, &refdata.refs, perf);
-    report_semis(verbose, "INITIAL SEMI ALIGNMENTS", &semi, &b_seq, refs, log);
+    report_semis(
+        verbose,
+        "INITIAL SEMI ALIGNMENTS",
+        &semi,
+        &b_seq,
+        &refdata.refs,
+        log,
+    );
 
     extend_matches(&b_seq, &refdata.refs, &mut semi);
 
@@ -367,15 +371,22 @@ pub fn annotate_seq_core(
     if allow_weak {
         extend_matches_to_end_of_reference(&b_seq, &refdata.refs, &mut semi);
     }
-    report_semis(verbose, "SEMI ALIGNMENTS", &semi, &b_seq, refs, log);
+    report_semis(
+        verbose,
+        "SEMI ALIGNMENTS",
+        &semi,
+        &b_seq,
+        &refdata.refs,
+        log,
+    );
 
-    extend_between_match_blocks(&b_seq, refs, &mut semi);
+    extend_between_match_blocks(&b_seq, &refdata.refs, &mut semi);
     report_semis(
         verbose,
         "SEMI ALIGNMENTS AFTER EXTENSION",
         &semi,
         &b_seq,
-        refs,
+        &refdata.refs,
         log,
     );
 
@@ -385,7 +396,7 @@ pub fn annotate_seq_core(
         "SEMI ALIGNMENTS AFTER MERGER",
         &semi,
         &b_seq,
-        refs,
+        &refdata.refs,
         log,
     );
 
@@ -395,7 +406,7 @@ pub fn annotate_seq_core(
         "SEMI ALIGNMENTS AFTER SECOND EXTENSION",
         &semi,
         &b_seq,
-        refs,
+        &refdata.refs,
         log,
     );
 
@@ -405,7 +416,7 @@ pub fn annotate_seq_core(
         "SEMI ALIGNMENTS AFTER SUBSUMPTION",
         &semi,
         &b_seq,
-        refs,
+        &refdata.refs,
         log,
     );
 

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -508,39 +508,7 @@ pub fn annotate_seq_core(
 
     downselect_to_best_c(&refdata.rheaders, &mut annx);
 
-    // Again remove UTR annotations that have no matching V annotation.
-    // ◼ DANGER with nonstandard references.
-    // ◼ Note repetition.
-
-    let mut to_delete: Vec<bool> = vec![false; annx.len()];
-    let (mut u, mut v) = (Vec::<String>::new(), Vec::<String>::new());
-    for a in &annx {
-        let t = a.ref_id as usize;
-        if !rheaders[t].contains("segment") {
-            let name = rheaders[t].after("|").between("|", "|");
-            if rheaders[t].contains("UTR") {
-                u.push(name.to_string());
-            }
-            if rheaders[t].contains("V-REGION") {
-                v.push(name.to_string());
-            }
-        }
-    }
-    v.sort();
-    for item in &u {
-        if !bin_member(&v, item) {
-            for j in 0..annx.len() {
-                let t = annx[j].ref_id as usize;
-                if !rheaders[t].contains("segment") {
-                    let name = rheaders[t].after("|").between("|", "|");
-                    if rheaders[t].contains("UTR") && item == name {
-                        to_delete[j] = true;
-                    }
-                }
-            }
-        }
-    }
-    erase_if(&mut annx, &to_delete);
+    remove_utr_without_matching_v(&refdata.rheaders, &mut annx);
 
     // Remove some subsumed extended annotations.
 

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -486,65 +486,7 @@ pub fn annotate_seq_core(
 
     retain_longer_j_segment(&b_seq, refdata, &mut annx);
 
-    // Pick between C segments starting at zero.  And favor zero.
-
-    let mut to_delete: Vec<bool> = vec![false; annx.len()];
-    for i1 in 0..annx.len() {
-        for i2 in 0..annx.len() {
-            if i2 == i1 {
-                continue;
-            }
-            let (t1, t2) = (annx[i1].ref_id as usize, annx[i2].ref_id as usize);
-            if rheaders[t1].contains("segment") || rheaders[t2].contains("segment") {
-                continue;
-            }
-            if !refdata.is_c(t1) || !refdata.is_c(t2) {
-                continue;
-            }
-            let (l1, l2) = (annx[i1].tig_start, annx[i2].tig_start);
-            let (p1, p2) = (annx[i1].ref_start, annx[i2].ref_start);
-            if p1 > 0 {
-                continue;
-            }
-            if p1 == 0 && p2 > 0 {
-                to_delete[i2] = true;
-            }
-            let (mut mis1, mut mis2) = (0, 0);
-            let (mut y1, mut y2) = (p1, p2);
-            let (mut x1, mut x2) = (l1, l2);
-            loop {
-                if b_seq[x1 as usize] != refs[t1].get(y1 as usize) {
-                    mis1 += 1;
-                }
-                if b_seq[x2 as usize] != refs[t2].get(y2 as usize) {
-                    mis2 += 1;
-                }
-                x1 += 1;
-                y1 += 1;
-                x2 += 1;
-                y2 += 1;
-                if x1 == b.len() as i32 || y1 == refs[t1].len() as i32 {
-                    break;
-                }
-                if x2 == b.len() as i32 || y2 == refs[t2].len() as i32 {
-                    break;
-                }
-            }
-
-            if mis1 == mis2 {
-                if refdata.name[t1] == *"TRBC1" && refdata.name[t2] == *"TRBC2" {
-                    continue;
-                }
-                if refdata.name[t2] == *"TRBC1" && refdata.name[t1] == *"TRBC2" {
-                    continue;
-                }
-            }
-            if mis1 < mis2 || (mis1 == mis2 && t1 < t2) {
-                to_delete[i2] = true;
-            }
-        }
-    }
-    erase_if(&mut annx, &to_delete);
+    retain_better_c_segment(&b_seq, b, refdata, &mut annx);
 
     // Pick between V segments starting at zero.  And favor zero.
 
@@ -2697,6 +2639,73 @@ fn retain_longer_j_segment(b_seq: &[u8], refdata: &RefData, annx: &mut Vec<PreAn
                 if mis1 < mis2 || (mis1 == mis2 && t1 < t2) {
                     to_delete[i2] = true;
                 }
+            }
+        }
+    }
+    erase_if(annx, &to_delete);
+}
+
+/// Pick between C segments starting at zero.  And favor zero.
+fn retain_better_c_segment(
+    b_seq: &[u8],
+    b: &DnaString,
+    refdata: &RefData,
+    annx: &mut Vec<PreAnnotation>,
+) {
+    let mut to_delete: Vec<bool> = vec![false; annx.len()];
+    for i1 in 0..annx.len() {
+        for i2 in 0..annx.len() {
+            if i2 == i1 {
+                continue;
+            }
+            let (t1, t2) = (annx[i1].ref_id as usize, annx[i2].ref_id as usize);
+            if refdata.rheaders[t1].contains("segment") || refdata.rheaders[t2].contains("segment")
+            {
+                continue;
+            }
+            if !refdata.is_c(t1) || !refdata.is_c(t2) {
+                continue;
+            }
+            let (l1, l2) = (annx[i1].tig_start, annx[i2].tig_start);
+            let (p1, p2) = (annx[i1].ref_start, annx[i2].ref_start);
+            if p1 > 0 {
+                continue;
+            }
+            if p1 == 0 && p2 > 0 {
+                to_delete[i2] = true;
+            }
+            let (mut mis1, mut mis2) = (0, 0);
+            let (mut y1, mut y2) = (p1, p2);
+            let (mut x1, mut x2) = (l1, l2);
+            loop {
+                if b_seq[x1 as usize] != refdata.refs[t1].get(y1 as usize) {
+                    mis1 += 1;
+                }
+                if b_seq[x2 as usize] != refdata.refs[t2].get(y2 as usize) {
+                    mis2 += 1;
+                }
+                x1 += 1;
+                y1 += 1;
+                x2 += 1;
+                y2 += 1;
+                if x1 == b.len() as i32 || y1 == refdata.refs[t1].len() as i32 {
+                    break;
+                }
+                if x2 == b.len() as i32 || y2 == refdata.refs[t2].len() as i32 {
+                    break;
+                }
+            }
+
+            if mis1 == mis2 {
+                if refdata.name[t1] == *"TRBC1" && refdata.name[t2] == *"TRBC2" {
+                    continue;
+                }
+                if refdata.name[t2] == *"TRBC1" && refdata.name[t1] == *"TRBC2" {
+                    continue;
+                }
+            }
+            if mis1 < mis2 || (mis1 == mis2 && t1 < t2) {
+                to_delete[i2] = true;
             }
         }
     }

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -506,32 +506,7 @@ pub fn annotate_seq_core(
 
     downselect_equally_performant_j_and_c(refdata, &mut annx);
 
-    // Pick between Cs.
-
-    let mut to_delete = vec![false; annx.len()];
-    for i1 in 0..annx.len() {
-        let t1 = annx[i1].ref_id;
-        if !rheaders[t1 as usize].contains("C-REGION") {
-            continue;
-        }
-        for i2 in 0..annx.len() {
-            let t2 = annx[i2].ref_id;
-            if !rheaders[t2 as usize].contains("C-REGION") {
-                continue;
-            }
-            let (l1, l2) = (annx[i1].tig_start as usize, annx[i2].tig_start as usize);
-            let (len1, len2) = (annx[i1].match_len as usize, annx[i2].match_len as usize);
-            // let (p1,p2) = (annx[i1].3,annx[i2].3);
-            if l1 + len1 != l2 + len2 {
-                continue;
-            }
-            if l1 + annx[i1].mismatches.len() >= l2 + annx[i2].mismatches.len() {
-                continue;
-            }
-            to_delete[i2] = true;
-        }
-    }
-    erase_if(&mut annx, &to_delete);
+    downselect_to_best_c(&refdata.rheaders, &mut annx);
 
     // Again remove UTR annotations that have no matching V annotation.
     // ◼ DANGER with nonstandard references.
@@ -2730,6 +2705,34 @@ fn downselect_equally_performant_j_and_c(refdata: &RefData, annx: &mut Vec<PreAn
                     to_delete[i2] = true;
                 }
             }
+        }
+    }
+    erase_if(annx, &to_delete);
+}
+
+/// Pick between Cs.
+fn downselect_to_best_c(rheaders: &[String], annx: &mut Vec<PreAnnotation>) {
+    let mut to_delete = vec![false; annx.len()];
+    for i1 in 0..annx.len() {
+        let t1 = annx[i1].ref_id;
+        if !rheaders[t1 as usize].contains("C-REGION") {
+            continue;
+        }
+        for i2 in 0..annx.len() {
+            let t2 = annx[i2].ref_id;
+            if !rheaders[t2 as usize].contains("C-REGION") {
+                continue;
+            }
+            let (l1, l2) = (annx[i1].tig_start as usize, annx[i2].tig_start as usize);
+            let (len1, len2) = (annx[i1].match_len as usize, annx[i2].match_len as usize);
+            // let (p1,p2) = (annx[i1].3,annx[i2].3);
+            if l1 + len1 != l2 + len2 {
+                continue;
+            }
+            if l1 + annx[i1].mismatches.len() >= l2 + annx[i2].mismatches.len() {
+                continue;
+            }
+            to_delete[i2] = true;
         }
     }
     erase_if(annx, &to_delete);

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -399,31 +399,7 @@ pub fn annotate_seq_core(
         log,
     );
 
-    // Delete some subsumed alignments.
-
-    let mut to_delete = vec![false; semi.len()];
-    let mut i = 0;
-    while i < semi.len() {
-        let mut j = i + 1;
-        while j < semi.len() {
-            if semi[j].ref_id != semi[i].ref_id || semi[j].offset != semi[i].offset {
-                break;
-            }
-            j += 1;
-        }
-        for k1 in i..j {
-            for k2 in i..j {
-                if semi[k1].offset + semi[k1].tig_start + semi[k1].len
-                    == semi[k2].offset + semi[k2].tig_start + semi[k2].len
-                    && semi[k1].len > semi[k2].len
-                {
-                    to_delete[k2] = true;
-                }
-            }
-        }
-        i = j;
-    }
-    erase_if(&mut semi, &to_delete);
+    remove_subsumed_alignments(&mut semi);
     report_semis(
         verbose,
         "SEMI ALIGNMENTS AFTER SUBSUMPTION",
@@ -2629,6 +2605,33 @@ fn extend_long_v_gene_alignments(b_seq: &[u8], refdata: &RefData, semi: &mut [Se
     for s in semi {
         unique_sort(&mut s.mismatches);
     }
+}
+
+/// Delete some subsumed alignments.
+fn remove_subsumed_alignments(semi: &mut Vec<SemiPerfectMatch>) {
+    let mut to_delete = vec![false; semi.len()];
+    let mut i = 0;
+    while i < semi.len() {
+        let mut j = i + 1;
+        while j < semi.len() {
+            if semi[j].ref_id != semi[i].ref_id || semi[j].offset != semi[i].offset {
+                break;
+            }
+            j += 1;
+        }
+        for k1 in i..j {
+            for k2 in i..j {
+                if semi[k1].offset + semi[k1].tig_start + semi[k1].len
+                    == semi[k2].offset + semi[k2].tig_start + semi[k2].len
+                    && semi[k1].len > semi[k2].len
+                {
+                    to_delete[k2] = true;
+                }
+            }
+        }
+        i = j;
+    }
+    erase_if(semi, &to_delete);
 }
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓


### PR DESCRIPTION
Mechanistic refactoring of the annotation code from a single straight-shot function into a collection of smaller individual pieces.  The only non-trivial changes to code were untangling the use of `std::mem::swap` left over from when the internal annotation types were tuples instead of structs.