### PR TITLE
collapse annotation helper types

### DIFF
--- a/enclone_args/src/read_json.rs
+++ b/enclone_args/src/read_json.rs
@@ -142,8 +142,7 @@ fn process_json_annotation(
     // Reannotate.
     if reannotate || ctl.gen_opt.reprod {
         let x = DnaString::from_dna_string(&ann.sequence);
-        let mut ann1 = Vec::<Annotation>::new();
-        annotate_seq(&x, refdata, &mut ann1, true, false, true);
+        let mut ann1 = annotate_seq(&x, refdata, true, false, true);
 
         // If there are multiple V segment alignments, possibly reduce to just one.
 

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -271,12 +271,6 @@ struct Alignment {
     pub mismatches: Vec<i32>,
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-struct Offset {
-    pub ref_id: i32,
-    pub offset: i32,
-}
-
 /// Minimum length of sequence we'll try to annotate.
 const K: usize = 12;
 
@@ -598,6 +592,12 @@ fn find_additional_perfect_matches(
     refs: &[DnaString],
     perf: &[Alignment],
 ) -> Vec<Alignment> {
+    #[derive(PartialEq, Eq, PartialOrd, Ord)]
+    struct Offset {
+        pub ref_id: i32,
+        pub offset: i32,
+    }
+
     let mut offsets = Vec::<Offset>::new();
     for p in perf {
         offsets.push(Offset {

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -780,6 +780,7 @@ fn extend_matches(b_seq: &[u8], refs: &[DnaString], semi: &mut [Alignment]) {
                 len += 1;
             }
         }
+        s.ref_start = l + off;
         s.tig_start = l;
         s.len = len;
         s.mismatches = mis;
@@ -892,6 +893,7 @@ fn extend_matches_to_end_of_reference(b_seq: &[u8], refs: &[DnaString], semi: &m
             len += 1;
         }
         if mis_count <= max_mis && l + off == 0 {
+            s.ref_start = l + off;
             s.tig_start = l;
             s.len = len;
             s.mismatches = mis;
@@ -965,6 +967,7 @@ fn merge_overlapping_alignments(semi: &mut Vec<Alignment>) {
                 if to_delete[k1] || to_delete[k2] {
                     continue;
                 }
+                let offset = semi[k1].offset();
                 let start1 = semi[k1].tig_start;
                 let start2 = semi[k2].tig_start;
                 let len1 = semi[k1].len;
@@ -974,6 +977,7 @@ fn merge_overlapping_alignments(semi: &mut Vec<Alignment>) {
                 let start = min(start1, start2);
                 let stop = max(stop1, stop2);
                 if stop - start <= len1 + len2 {
+                    semi[k1].ref_start = start + offset;
                     semi[k1].tig_start = start;
                     semi[k1].len = stop - start;
                     let mut m2 = semi[k2].mismatches.clone();

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -413,16 +413,7 @@ pub fn annotate_seq_core(
         log,
     );
 
-    let mut annx: Vec<_> = semi
-        .into_iter()
-        .map(|x| Alignment {
-            tig_start: x.tig_start,
-            len: x.len,
-            ref_id: x.ref_id,
-            ref_start: x.ref_start,
-            mismatches: x.mismatches,
-        })
-        .collect();
+    let mut annx = semi;
     annx.sort_by(Alignment::cmp_by_tig_start_len);
     annx.dedup();
 

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -714,7 +714,7 @@ fn merge_perfect_matches(b_seq: &[u8], refs: &[DnaString], perf: Vec<Alignment>)
             }
             semi.push(Alignment {
                 ref_id: t,
-                ref_start: off + perf[k1].tig_start,
+                ref_start: perf[k1].ref_start,
                 tig_start: perf[k1].tig_start,
                 len: perf[k2].tig_start + perf[k2].len - perf[k1].tig_start,
                 mismatches: m,

--- a/vdj_ann_ref/src/lib.rs
+++ b/vdj_ann_ref/src/lib.rs
@@ -116,8 +116,6 @@ pub fn make_vdj_ref_data(
 
 #[cfg(test)]
 mod tests {
-    use vdj_ann::annotate::Annotation;
-
     use super::*;
 
     // The following test checks for alignment of a D region.  This example was fixed by code
@@ -141,8 +139,7 @@ mod tests {
         let (is_tcr, is_bcr) = (true, false);
         let mut refdata = RefData::new();
         make_vdj_ref_data_core(&mut refdata, refx, &ext_refx, is_tcr, is_bcr, None);
-        let mut ann = Vec::<Annotation>::new();
-        annotate_seq(&seq, &refdata, &mut ann, true, false, true);
+        let ann = annotate_seq(&seq, &refdata, true, false, true);
         let mut have_d = false;
         for a in ann {
             if refdata.is_d(a.ref_id as usize) {


### PR DESCRIPTION
Collapses the three intermediate annotation types into a single `Alignment` struct. This was carefully done in a series of systematic steps; this PR may be easier to review commit-by-commit rather than viewing the entire diff as a unit.