### PR TITLE
Ignore RUSTSEC-2024-0336.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,7 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    "RUSTSEC-2024-0336",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Fix needed is upstream in rust-hdf5 and since none of this code implements a web server, we don't really care about this.